### PR TITLE
Accept on_pending_authorization param in login

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -44,13 +44,13 @@ While the functions that require the user to be logged in let you specify `login
 If the user is not logged in or `force_refresh` is `True`, it will attempt to log in.
 If the user is logged in and `force_refresh` is `False`, no action is taken.
 
-Normally, it will attempt to automatically open the user's browser to log in, as well as printing the URL and code to stderr as a fallback. However, if `disable_browser` is `True`, or if `disable_browser` is `None` (the default) and the environment variable `AWS_SSO_DISABLE_BROWSER` is set to `1` or `true`, only the message with the URL and code will be printed.
+Normally, it will attempt to automatically open the user's browser to log in, as well as printing the URL and code to stderr as a fallback. However, if `disable_browser` is `True`, or if `disable_browser` is `None` (the default) and the environment variable `AWS_SSO_DISABLE_BROWSER` is set to `1` or `true`, only the message with the URL and code will be printed. If `on_pending_authorization` is set, the URL and code are provided through this callback, no message is printed, and a browser is not launched.
 
 A custom message can be printed by setting `message` to a template string using `{url}` and `{code}` as placeholders.
 The message can be suppressed by setting `message` to `False`.
 
 ```python
-login(start_url, sso_region, force_refresh=False, expiry_window=None, disable_browser=None, message=None, outfile=None)
+login(start_url, sso_region, force_refresh=False, expiry_window=None, disable_browser=None, message=None, outfile=None, sso_cache=None, on_pending_authorization=None)
 ```
 
 * `start_url`: [REQUIRED] The start URL for the AWS SSO instance.
@@ -60,6 +60,8 @@ login(start_url, sso_region, force_refresh=False, expiry_window=None, disable_br
 * `disable_browser`: Set to `True` to skip the browser popup and only print a message with the URL and code.
 * `message`: A message template to print with the fallback URL and code, or `False` to suppress the message.
 * `outfile`: The file-like object to print the message to (stderr by default)
+* `sso_cache`: A dict-like object for AWS SSO credential caching (`None` by default)
+* `on_pending_authorization`: A callable invoked with URL and code parameters for interactive login (`None` by default). Specifying this value disables the browser popup. 
 * Returns the token dict as returned by [sso-oidc:CreateToken](https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html), which contains the actual authorization token, as well as the expiration.
 
 ## `list_available_accounts` and `list_available_roles`

--- a/lib/aws_sso_lib/sso.py
+++ b/lib/aws_sso_lib/sso.py
@@ -261,8 +261,7 @@ def login(
         disable_browser=disable_browser,
         sso_cache=sso_cache,
         expiry_window=expiry_window,
-        on_pending_authorization=on_pending_authorization
-    )
+        on_pending_authorization=on_pending_authorization)
 
     token = token_fetcher.fetch_token(
         start_url=start_url,

--- a/lib/aws_sso_lib/sso.py
+++ b/lib/aws_sso_lib/sso.py
@@ -214,7 +214,8 @@ def login(
         message: str=None,
         outfile: typing.Union[typing.TextIO, bool]=None,
         sso_cache=None,
-        expiry_window=None,) -> typing.Dict:
+        expiry_window=None,
+        on_pending_authorization: typing.Callable=None) -> typing.Dict:
     """Interactively log in the user if their AWS SSO credentials have expired.
 
     If the user is not logged in or force_refresh is True, it will attempt to log in.
@@ -242,6 +243,8 @@ def login(
         expiry_window: An int or datetime.timedelta, or callable returning such,
             specifying the minimum duration in seconds any existing token
             must be valid for.
+        on_pending_authorization (function): A function called with the fallback URL and code instead of launching
+            a browser or printing a message
 
     Returns:
         The token dict as returned by sso-oidc:CreateToken,
@@ -257,7 +260,9 @@ def login(
         outfile=outfile,
         disable_browser=disable_browser,
         sso_cache=sso_cache,
-        expiry_window=expiry_window)
+        expiry_window=expiry_window,
+        on_pending_authorization=on_pending_authorization
+    )
 
     token = token_fetcher.fetch_token(
         start_url=start_url,


### PR DESCRIPTION
In order to support a headless scenario running in a containerised notebook environment, I wanted to receive the code and URL via a callback. Since the `get_token_fetcher` already supports `on_pending_authorization`, this PR exposes same as an optional parameter in `login`.

I hope this makes some sense - I'm happy to rework this any other way. Thanks for this library @benkehoe!