### PR TITLE
add profile case transformations to "aws-sso-util configure populate"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 * [Eoin Shanaghy](https://github.com/eoinsha)
 * [Geordam](https://github.com/Geordam)
 * [Imran](https://github.com/fai555)
+* [O'Shaughnessy Evans](https://github.com/oshaughnessy)

--- a/cli/src/aws_sso_util/populate_profiles.py
+++ b/cli/src/aws_sso_util/populate_profiles.py
@@ -164,6 +164,8 @@ def get_name_case_formatter(account_name_transform, role_name_transform, formatt
                 kwargs[field] = kwargs[field].casefold()
             elif transform == "lower":
                 kwargs[field] = kwargs[field].lower()
+            elif transform == "title":
+                kwargs[field] = kwargs[field].title()
             elif transform == "upper":
                 kwargs[field] = kwargs[field].upper()
             else:
@@ -191,8 +193,8 @@ def get_safe_account_name(name):
 @click.option("--region-style", "profile_name_region_style", type=click.Choice(["short", "long"]), default="short", help="Default is five character region abbreviations")
 @click.option("--trim-account-name", "profile_name_trim_account_name_patterns", multiple=True, default=[], help="Regex to remove from account names, can provide multiple times")
 @click.option("--trim-role-name", "profile_name_trim_role_name_patterns", multiple=True, default=[], help="Regex to remove from role names, can provide multiple times")
-@click.option("--account-name-case", "profile_name_account_name_case_transform", type=click.Choice(["capitalize", "casefold", "lower", "upper"]), help="Method to change the case of the account name")
-@click.option("--role-name-case", "profile_name_role_name_case_transform", type=click.Choice(["capitalize", "casefold", "lower", "upper"]), help="Method to change the case of the role name")
+@click.option("--account-name-case", "profile_name_account_name_case_transform", type=click.Choice(["capitalize", "casefold", "lower", "title", "upper"]), help="Method to change the case of the account name")
+@click.option("--role-name-case", "profile_name_role_name_case_transform", type=click.Choice(["capitalize", "casefold", "lower", "title", "upper"]), help="Method to change the case of the role name")
 @click.option("--profile-name-process")
 @click.option("--safe-account-names/--raw-account-names", default=True, help="In profiles, replace any character sequences in account names not in A-Za-z0-9-._ with a single -")
 

--- a/cli/src/aws_sso_util/populate_profiles.py
+++ b/cli/src/aws_sso_util/populate_profiles.py
@@ -156,6 +156,8 @@ def get_name_case_formatter(account_name_transform, role_name_transform, formatt
     }
     def case_formatter(i, n, **kwargs):
         for field, transform in field_transform_map.items():
+            if not transform:
+                continue
             if transform == "capitalize":
                 kwargs[field] = kwargs[field].capitalize()
             elif transform == "casefold":

--- a/cli/src/aws_sso_util/populate_profiles.py
+++ b/cli/src/aws_sso_util/populate_profiles.py
@@ -149,20 +149,21 @@ def get_trim_formatter(account_name_patterns, role_name_patterns, formatter):
         return formatter(i, n, **kwargs)
     return trim_formatter
 
-def get_field_name_case_formatter(field, transform, formatter):
+def get_name_case_formatter(account_name_transform, role_name_transform, formatter):
+    field_transform_map = {
+        "account_name": account_name_transform,
+        "role_name": role_name_transform,
+    }
     def case_formatter(i, n, **kwargs):
-        LOGGER.debug("evaluating case transform(%s)", transform)
-        LOGGER.debug("* in  = %s", kwargs[field])
-        if transform == 'capitalize':
-            transformation = lambda s: s.capitalize()
-        elif transform == 'casefold':
-            transformation = lambda s: s.casefold()
-        elif transform == 'lower':
-            transformation = lambda s: s.lower()
-        elif transform == 'upper':
-            transformation = lambda s: s.upper()
-        kwargs[field] = (transformation)(kwargs[field])
-        LOGGER.debug("* out = %s", kwargs[field])
+        for field, transform in field_transform_map.items():
+            if transform == "capitalize":
+                kwargs[field] = kwargs[field].capitalize()
+            elif transform == "casefold":
+                kwargs[field] = kwargs[field].casefold()
+            elif transform == "lower":
+                kwargs[field] = kwargs[field].lower()
+            elif transform == "upper":
+                kwargs[field] = kwargs[field].upper()
         return formatter(i, n, **kwargs)
     return case_formatter
 
@@ -265,10 +266,8 @@ def populate_profiles(
         profile_name_formatter = get_formatter(profile_name_include_region, region_format, no_region_format)
         if profile_name_trim_account_name_patterns or profile_name_trim_role_name_patterns:
             profile_name_formatter = get_trim_formatter(profile_name_trim_account_name_patterns, profile_name_trim_role_name_patterns, profile_name_formatter)
-        if profile_name_account_name_case_transform:
-            profile_name_formatter = get_field_name_case_formatter("account_name", profile_name_account_name_case_transform, profile_name_formatter)
-        if profile_name_role_name_case_transform:
-            profile_name_formatter = get_field_name_case_formatter("role_name", profile_name_role_name_case_transform, profile_name_formatter)
+        if profile_name_account_name_case_transform or profile_name_role_name_case_transform:
+            profile_name_formatter = get_name_case_formatter(profile_name_account_name_case_transform, profile_name_role_name_case_transform, profile_name_formatter)
 
     try:
         profile_name_formatter(0, 1, account_name="foo", account_id="bar", role_name="baz", region="us-east-1")

--- a/cli/src/aws_sso_util/populate_profiles.py
+++ b/cli/src/aws_sso_util/populate_profiles.py
@@ -164,6 +164,8 @@ def get_name_case_formatter(account_name_transform, role_name_transform, formatt
                 kwargs[field] = kwargs[field].lower()
             elif transform == "upper":
                 kwargs[field] = kwargs[field].upper()
+            else:
+                raise ValueError("Unknown {} transform value {}".format(field, transform))
         return formatter(i, n, **kwargs)
     return case_formatter
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -157,6 +157,74 @@ aws s3 ls --profile my-sso-profile
 `aws-sso-util configure populate` allows you to configure profiles for all the access you have through AWS SSO.
 You specify one or more regions, and a profile is created for every account, role, and region you have access to through AWS SSO (note that if access to a region is prohibited by an IAM policy, this does not suppress creation of the profile).
 
+## Options
+
+    Usage: aws-sso-util configure populate [OPTIONS]
+
+      Configure profiles for all accounts and roles.
+
+      Writes a profile to your AWS config file (~/.aws/config) for every account
+      and role you have access to, for the regions you specify.
+
+    Options:
+      -u, --sso-start-url URL         Your AWS SSO start URL
+      --sso-region TEXT               The AWS region your AWS SSO instance is
+                                      deployed in
+
+      -r, --region REGION             AWS region for the profiles, can provide
+                                      multiple times
+
+      --dry-run                       Print the config to stdout instead of
+                                      writing to your config file
+
+      -c, --config-default KEY=VALUE  Additional config field to set, can provide
+                                      multiple times
+
+      --existing-config-action [keep|overwrite|discard]
+                                      Action when config defaults conflict with
+                                      existing settings
+
+      --components VALUE,VALUE,...    Profile name components to join (comma-
+                                      separated). Possible values are:
+                                      account_name account_id account_number
+                                      role_name region short_region
+
+      --separator, --sep SEP          Separator for profile name components,
+                                      default is '.'
+
+      --include-region [default|always]
+                                      By default, the first region is left off the
+                                      profile name
+
+      --region-style [short|long]     Default is five character region
+                                      abbreviations
+
+      --trim-account-name TEXT        Regex to remove from account names, can
+                                      provide multiple times
+
+      --trim-role-name TEXT           Regex to remove from role names, can provide
+                                      multiple times
+
+      --account-name-case [capitalize|casefold|lower|upper]
+                                      Method to change the case of the account
+                                      name
+
+      --role-name-case [capitalize|casefold|lower|upper]
+                                      Method to change the case of the role name
+      --profile-name-process TEXT
+      --safe-account-names / --raw-account-names
+                                      In profiles, replace any character sequences
+                                      in account names not in A-Za-z0-9-._ with a
+                                      single -
+
+      --credential-process / --no-credential-process
+                                      Force enable/disable setting the credential
+                                      process SDK helper
+
+      --force-refresh                 Re-login
+      -v, --verbose
+      --help                          Show this message and exit.
+
 You can provide regions through the `--region`/`-r` flag (multiple regions like `-r REGION1 -r REGION2`), or by setting the `AWS_CONFIGURE_DEFAULT_REGION` environment variable (this is ignored if any regions are specified on the command line).
 
 You can view the profiles without writing them using the `--dry-run` flag.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -236,3 +236,16 @@ region_str = "" if region_index == 0 else sep + short_region_name
 print(account_name + sep + role_name + region_str)
 ```
 If this was stored as `profile_formatter.py`, it could be used as `--profile-name-process "python profile_formatter.py"`
+
+### Transform profile names
+
+If you don't want to run (and maintain) a process completely outside of the
+`--profile-name-process`, an option between trimming account & role names
+and executing a separate process is available through `--transform-profile-name`.
+Use this to change a generated profile name after assembly and trimming by
+running the name through Python code.
+
+For example, to lowercase the profile name, pass it through a Lambda:
+
+```
+    --transform-profile-name 'lambda x: x.lower()'

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -237,39 +237,25 @@ print(account_name + sep + role_name + region_str)
 ```
 If this was stored as `profile_formatter.py`, it could be used as `--profile-name-process "python profile_formatter.py"`
 
-### Transform profile names
+### Change the case of profile names
 
 If you don't want to run (and maintain) a process completely outside of the
-`--profile-name-process`, an option between trimming account/role names
-and executing a separate process is available through `--transform-profile-name`.
-Use this to change a generated profile name after assembly and trimming by
-running the name through some common Python string functions.
+`--profile-name-process`, an option between trimming account & role names and
+executing a separate process is available with `--account-name-case` and
+`--role-name-case`. Use these to change the generated profile names after
+assembly and trimming.
 
-For example, to lowercase the profile name, apply the "lower" transform:
+Case modifications include:
 
-    --transform-profile-name lower
-
-transforms include some [common Python string methods](https://docs.python.org/3/library/stdtypes.html#string-methods):
-
-    * `alnum`
-    * `ascii`
     * `capitalize`
     * `casefold`
     * `lower`
-    * `swapcase`
-    * `title`
     * `upper`
+
+For example, to lowercase both the account name and role name, add these options:
+
+    --account-name-case lower --role-name-case lower
 
 If you want to see what it does, try a dry run:
 
-    aws-sso-util configure populate --region $AWS_REGION --dry-run --transform-profile-name swapcase
-
-Note that you can run more than one transform. This doesn't make sense for all of the options, but
-may be useful if you want to strip characters and then change case. As an experimental no-op,
-try this to see your case-swapped profiles get back to their original case:
-
-    aws-sso-util configure populate --region $AWS_REGION --dry-run --transform-profile-name swapcase --transform-profile-name swapcase
-
-A more practical example might be to trim all non-alphabetic and non-numeric characters:
-
-    aws-sso-util configure populate --region $AWS_REGION --dry-run --transform-profile-name alnum --transform-profile-name lower
+    aws-sso-util configure populate --region $AWS_REGION --dry-run --account-name-case lower --role-name-case lower

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -157,74 +157,6 @@ aws s3 ls --profile my-sso-profile
 `aws-sso-util configure populate` allows you to configure profiles for all the access you have through AWS SSO.
 You specify one or more regions, and a profile is created for every account, role, and region you have access to through AWS SSO (note that if access to a region is prohibited by an IAM policy, this does not suppress creation of the profile).
 
-## Options
-
-    Usage: aws-sso-util configure populate [OPTIONS]
-
-      Configure profiles for all accounts and roles.
-
-      Writes a profile to your AWS config file (~/.aws/config) for every account
-      and role you have access to, for the regions you specify.
-
-    Options:
-      -u, --sso-start-url URL         Your AWS SSO start URL
-      --sso-region TEXT               The AWS region your AWS SSO instance is
-                                      deployed in
-
-      -r, --region REGION             AWS region for the profiles, can provide
-                                      multiple times
-
-      --dry-run                       Print the config to stdout instead of
-                                      writing to your config file
-
-      -c, --config-default KEY=VALUE  Additional config field to set, can provide
-                                      multiple times
-
-      --existing-config-action [keep|overwrite|discard]
-                                      Action when config defaults conflict with
-                                      existing settings
-
-      --components VALUE,VALUE,...    Profile name components to join (comma-
-                                      separated). Possible values are:
-                                      account_name account_id account_number
-                                      role_name region short_region
-
-      --separator, --sep SEP          Separator for profile name components,
-                                      default is '.'
-
-      --include-region [default|always]
-                                      By default, the first region is left off the
-                                      profile name
-
-      --region-style [short|long]     Default is five character region
-                                      abbreviations
-
-      --trim-account-name TEXT        Regex to remove from account names, can
-                                      provide multiple times
-
-      --trim-role-name TEXT           Regex to remove from role names, can provide
-                                      multiple times
-
-      --account-name-case [capitalize|casefold|lower|upper]
-                                      Method to change the case of the account
-                                      name
-
-      --role-name-case [capitalize|casefold|lower|upper]
-                                      Method to change the case of the role name
-      --profile-name-process TEXT
-      --safe-account-names / --raw-account-names
-                                      In profiles, replace any character sequences
-                                      in account names not in A-Za-z0-9-._ with a
-                                      single -
-
-      --credential-process / --no-credential-process
-                                      Force enable/disable setting the credential
-                                      process SDK helper
-
-      --force-refresh                 Re-login
-      -v, --verbose
-      --help                          Show this message and exit.
-
 You can provide regions through the `--region`/`-r` flag (multiple regions like `-r REGION1 -r REGION2`), or by setting the `AWS_CONFIGURE_DEFAULT_REGION` environment variable (this is ignored if any regions are specified on the command line).
 
 You can view the profiles without writing them using the `--dry-run` flag.
@@ -290,10 +222,6 @@ The values for these options are as follows, and correspond to the Python string
 For example, to lowercase both the account name and role name, add these options:
 
     --account-name-case lower --role-name-case lower
-
-If you want to see what it does, try a dry run:
-
-    aws-sso-util configure populate --region $AWS_REGION --dry-run --account-name-case lower --role-name-case lower
 
 ### Profile name process
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -274,6 +274,27 @@ A useful piece of syntax for this is lookahead/lookbehind assertions.
 * `(?<!My)Role` would turn `"AdminRole"` into `"Admin"` and `"UserRole"` into `"User"` but leave `"MyRole"` as is.
 * `RoleFor(?=Admin)` and `RoleFor(?!My)` work similarly for suffixes.
 
+### Change the case of account and role names
+
+You can alter the case of your profile names with `--account-name-case` and
+`--role-name-case`. Use these to change the generated profile names after
+assembly and trimming.
+
+The values for these options are as follows, and correspond to the Python string methods of the same names:
+
+* [`capitalize`](https://docs.python.org/3/library/stdtypes.html#str.capitalize)
+* [`casefold`](https://docs.python.org/3/library/stdtypes.html#str.casefold)
+* [`lower`](https://docs.python.org/3/library/stdtypes.html#str.lower)
+* [`upper`](https://docs.python.org/3/library/stdtypes.html#str.upper)
+
+For example, to lowercase both the account name and role name, add these options:
+
+    --account-name-case lower --role-name-case lower
+
+If you want to see what it does, try a dry run:
+
+    aws-sso-util configure populate --region $AWS_REGION --dry-run --account-name-case lower --role-name-case lower
+
 ### Profile name process
 
 Finally, if you want total control over the generated profile names, you can provide a shell command with `--profile-name-process` and it will be executed with the following positional arguments:
@@ -304,26 +325,3 @@ region_str = "" if region_index == 0 else sep + short_region_name
 print(account_name + sep + role_name + region_str)
 ```
 If this was stored as `profile_formatter.py`, it could be used as `--profile-name-process "python profile_formatter.py"`
-
-### Change the case of profile names
-
-If you don't want to run (and maintain) a process completely outside of the
-`--profile-name-process`, an option between trimming account & role names and
-executing a separate process is available with `--account-name-case` and
-`--role-name-case`. Use these to change the generated profile names after
-assembly and trimming.
-
-Case modifications include:
-
-    * `capitalize`
-    * `casefold`
-    * `lower`
-    * `upper`
-
-For example, to lowercase both the account name and role name, add these options:
-
-    --account-name-case lower --role-name-case lower
-
-If you want to see what it does, try a dry run:
-
-    aws-sso-util configure populate --region $AWS_REGION --dry-run --account-name-case lower --role-name-case lower

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -240,12 +240,36 @@ If this was stored as `profile_formatter.py`, it could be used as `--profile-nam
 ### Transform profile names
 
 If you don't want to run (and maintain) a process completely outside of the
-`--profile-name-process`, an option between trimming account & role names
+`--profile-name-process`, an option between trimming account/role names
 and executing a separate process is available through `--transform-profile-name`.
 Use this to change a generated profile name after assembly and trimming by
-running the name through Python code.
+running the name through some common Python string functions.
 
-For example, to lowercase the profile name, pass it through a Lambda:
+For example, to lowercase the profile name, apply the "lower" transform:
 
-```
-    --transform-profile-name 'lambda x: x.lower()'
+    --transform-profile-name lower
+
+transforms include some [common Python string methods](https://docs.python.org/3/library/stdtypes.html#string-methods):
+
+    * `alnum`
+    * `ascii`
+    * `capitalize`
+    * `casefold`
+    * `lower`
+    * `swapcase`
+    * `title`
+    * `upper`
+
+If you want to see what it does, try a dry run:
+
+    aws-sso-util configure populate --region $AWS_REGION --dry-run --transform-profile-name swapcase
+
+Note that you can run more than one transform. This doesn't make sense for all of the options, but
+may be useful if you want to strip characters and then change case. As an experimental no-op,
+try this to see your case-swapped profiles get back to their original case:
+
+    aws-sso-util configure populate --region $AWS_REGION --dry-run --transform-profile-name swapcase --transform-profile-name swapcase
+
+A more practical example might be to trim all non-alphabetic and non-numeric characters:
+
+    aws-sso-util configure populate --region $AWS_REGION --dry-run --transform-profile-name alnum --transform-profile-name lower

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -217,6 +217,7 @@ The values for these options are as follows, and correspond to the Python string
 * [`capitalize`](https://docs.python.org/3/library/stdtypes.html#str.capitalize)
 * [`casefold`](https://docs.python.org/3/library/stdtypes.html#str.casefold)
 * [`lower`](https://docs.python.org/3/library/stdtypes.html#str.lower)
+* [`title`](https://docs.python.org/3/library/stdtypes.html#str.title)
 * [`upper`](https://docs.python.org/3/library/stdtypes.html#str.upper)
 
 For example, to lowercase both the account name and role name, add these options:


### PR DESCRIPTION
which provides a way to evaluate Python code against profile names that are built from components, giving a CLI middle ground between trimming regexes and invoking a separate script