### PR TITLE
Release CLI v4.28 and lib v1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## `aws-sso-util`
 
+### CLI v4.28
+* Log normal output to stdout ([#54](https://github.com/benkehoe/aws-sso-util/issues/54)).
+* Fix short region names for GovCloud in `aws-sso-util configure populate` and `aws-sso-util configure profile` ([#55](https://github.com/benkehoe/aws-sso-util/issues/55)).
+* Update `aws-sso-util login` to use `--force-refresh` for consistency with other commands (`--force` still works).
+* `aws-sso-util check` now provides more information about the token cache.
+
 ### CLI v4.27
 * Added `--account-name-case` and `--role-name-case` to `aws-sso-util configure populate` ([#48](https://github.com/benkehoe/aws-sso-util/pull/48)).
 * `aws-sso-util check` logs version and timestamp information.
@@ -41,6 +47,10 @@
 * Fix name fetching error with `!Ref` principal or target
 
 ## `aws-sso-lib`
+
+### lib v1.11
+* Improvements to `SSOTokenFetcher` to support better `aws-sso-util check` functionality.
+* Fixed type annotations.
 
 ### lib v1.10
 * `lookup_accounts_for_ou()` now caches calls to `organizations.DescribeOrganization`.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ aws-sso-util --help
 4. Autocomplete
 
 `aws-sso-util` uses [click](https://click.palletsprojects.com/en/7.x/), which supports autocompletion.
-The details of enabling shell completion with click vary by shell ([instructions here](https://click.palletsprojects.com/en/7.x/bashcomplete/)), but here is an example for bash that updates the completion in the background.
+The details of enabling shell completion with click vary by shell ([instructions here](https://click.palletsprojects.com/en/7.x/bashcomplete/)), but here is an example for `.bashrc` that updates the completion script in the background.
 
 ```bash
 _AWS_SSO_UTIL_COMPLETE_SCRIPT_DIR=~/.local/share/aws-sso-util

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-sso-util"
-version = "4.27.0" # change in aws_sso_util/__init__.py too
+version = "4.28.0" # change in aws_sso_util/__init__.py too
 description = "Utilities to make AWS SSO easier"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ pyyaml = "^5.3.1"
 jsonschema = "^3.2.0"
 aws-error-utils = "^1.0.4"
 python-dateutil = "^2.8.1"
-aws-sso-lib = "^1.9.0"
+aws-sso-lib = "^1.11.0"
 # aws-sso-lib = { path = "../lib" }
 requests = "^2.26.0"
 

--- a/cli/src/aws_sso_util/__init__.py
+++ b/cli/src/aws_sso_util/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '4.27.0' # change in pyproject.toml too
+__version__ = '4.28.0' # change in pyproject.toml too

--- a/cli/src/aws_sso_util/__init__.py
+++ b/cli/src/aws_sso_util/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 __version__ = '4.27.0' # change in pyproject.toml too

--- a/cli/src/aws_sso_util/__main__.py
+++ b/cli/src/aws_sso_util/__main__.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/assignments.py
+++ b/cli/src/aws_sso_util/assignments.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/cfn.py
+++ b/cli/src/aws_sso_util/cfn.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/cfn_lib/__init__.py
+++ b/cli/src/aws_sso_util/cfn_lib/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/src/aws_sso_util/cfn_lib/config.py
+++ b/cli/src/aws_sso_util/cfn_lib/config.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/cfn_lib/macro.py
+++ b/cli/src/aws_sso_util/cfn_lib/macro.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/cfn_lib/resources.py
+++ b/cli/src/aws_sso_util/cfn_lib/resources.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/cfn_lib/templates.py
+++ b/cli/src/aws_sso_util/cfn_lib/templates.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/cfn_lib/utils.py
+++ b/cli/src/aws_sso_util/cfn_lib/utils.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/check.py
+++ b/cli/src/aws_sso_util/check.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import logging
 import sys
 import re

--- a/cli/src/aws_sso_util/cli.py
+++ b/cli/src/aws_sso_util/cli.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/configure_profile.py
+++ b/cli/src/aws_sso_util/configure_profile.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/aws_sso_util/console.py
+++ b/cli/src/aws_sso_util/console.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import logging
 import sys
 import json

--- a/cli/src/aws_sso_util/credential_process.py
+++ b/cli/src/aws_sso_util/credential_process.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/aws_sso_util/deploy_macro.py
+++ b/cli/src/aws_sso_util/deploy_macro.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/login.py
+++ b/cli/src/aws_sso_util/login.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/logout.py
+++ b/cli/src/aws_sso_util/logout.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/lookup.py
+++ b/cli/src/aws_sso_util/lookup.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/populate_profiles.py
+++ b/cli/src/aws_sso_util/populate_profiles.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/populate_profiles.py
+++ b/cli/src/aws_sso_util/populate_profiles.py
@@ -50,19 +50,26 @@ LOGGER = logging.getLogger(__name__)
 ConfigParams = namedtuple("ConfigParams", ["profile_name", "account_name", "account_id", "role_name", "region"])
 
 def get_short_region(region):
-    area, direction, num = region.split("-")
-    dir_abbr = {
-        "north": "no",
-        "northeast": "ne",
-        "east": "ea",
-        "southeast": "se",
-        "south": "so",
-        "southwest": "sw",
-        "west": "we",
-        "northwest": "nw",
-        "central": "ce",
-    }
-    return "".join([area, dir_abbr.get(direction, direction), num])
+    try:
+        area, direction, num = region.rsplit("-", 2)
+        area_abbr = {
+            "us-gov": "gov"
+        }
+        dir_abbr = {
+            "north": "no",
+            "northeast": "ne",
+            "east": "ea",
+            "southeast": "se",
+            "south": "so",
+            "southwest": "sw",
+            "west": "we",
+            "northwest": "nw",
+            "central": "ce",
+        }
+        return "".join([area_abbr.get(area, area), dir_abbr.get(direction, direction), num])
+    except Exception as e:
+        LOGGER.debug(f"Error creating short region: {e}", exc_info=True)
+        return region
 
 KNOWN_COMPONENTS = [
     "account_name",

--- a/cli/src/aws_sso_util/roles.py
+++ b/cli/src/aws_sso_util/roles.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import logging
 import re
 import sys

--- a/cli/src/aws_sso_util/run_as.py
+++ b/cli/src/aws_sso_util/run_as.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import logging
 import sys
 import os

--- a/cli/src/aws_sso_util/utils.py
+++ b/cli/src/aws_sso_util/utils.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/cli/src/aws_sso_util/utils.py
+++ b/cli/src/aws_sso_util/utils.py
@@ -13,8 +13,13 @@
 
 import logging
 import logging.handlers
+import sys
 
 from aws_sso_lib.config import find_instances, SSOInstance
+
+class StdoutFilter(logging.Filter):
+    def filter(self, rec):
+        return rec.levelno < logging.WARNING
 
 def configure_logging(logger, verbose, **config_args):
     if verbose in [False, None]:
@@ -29,9 +34,18 @@ def configure_logging(logger, verbose, **config_args):
     root_logger = logging.getLogger()
 
     if verbose == 0:
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        logger.addHandler(handler)
+        stdout_handler = logging.StreamHandler(stream=sys.stdout)
+        stdout_handler.setFormatter(logging.Formatter("%(message)s"))
+        stdout_handler.setLevel(logging.DEBUG)
+        stdout_handler.addFilter(StdoutFilter())
+
+        stderr_handler = logging.StreamHandler(stream=sys.stderr)
+        stderr_handler.setFormatter(logging.Formatter("%(message)s"))
+        stderr_handler.setLevel(logging.WARNING)
+
+        logger.addHandler(stdout_handler)
+        logger.addHandler(stderr_handler)
+
         logger.propagate = False
         logger.setLevel(logging.INFO)
     elif verbose == 1:

--- a/cli/src/cfn_macro_handler.py
+++ b/cli/src/cfn_macro_handler.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 from aws_sso_util.cfn_lib import macro
 
 handler = macro.handler

--- a/docs/login.md
+++ b/docs/login.md
@@ -42,7 +42,7 @@ If you're finding that it's not correctly selecting the right instance, you can 
 
 ## Other options
 
-Use `--force` to ignore any cached tokens.
+Use `--force-refresh` to ignore any cached tokens.
 
 On headless systems, the attempt to pop up the browser will silently fail and the always-printed fallback message with the URL and code can be used.
 If you are on a system with a browser but you do not want the automatic pop up, use `--headless` or set the environment variable `AWS_SSO_DISABLE_BROWSER` to `1` or `true`.

--- a/lib/aws_sso_lib/__init__.py
+++ b/lib/aws_sso_lib/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 __version__ = '1.10.0' # change in pyproject.toml too
 
 from .sso import get_boto3_session, login, list_available_accounts, list_available_roles

--- a/lib/aws_sso_lib/__init__.py
+++ b/lib/aws_sso_lib/__init__.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-__version__ = '1.10.0' # change in pyproject.toml too
+__version__ = '1.11.0' # change in pyproject.toml too
 
 from .sso import get_boto3_session, login, list_available_accounts, list_available_roles
 from .assignments import Assignment, list_assignments

--- a/lib/aws_sso_lib/assignments.py
+++ b/lib/aws_sso_lib/assignments.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import re
 import numbers
 import collections

--- a/lib/aws_sso_lib/browser.py
+++ b/lib/aws_sso_lib/browser.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/lib/aws_sso_lib/config.py
+++ b/lib/aws_sso_lib/config.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/lib/aws_sso_lib/config.py
+++ b/lib/aws_sso_lib/config.py
@@ -15,6 +15,7 @@ import os
 import logging
 import re
 from collections import namedtuple
+from typing import Optional
 
 import botocore
 from botocore.exceptions import ProfileNotFound
@@ -54,7 +55,7 @@ class SSOInstance(namedtuple("SSOInstance", ["start_url", "region", "start_url_s
     def to_strs(cls, instances, region=None):
         return ", ".join(i.to_str(region=region) for i in instances)
 
-def _get_instance_from_profile(profile_name, scoped_config: dict, missing_ok=False) -> SSOInstance:
+def _get_instance_from_profile(profile_name, scoped_config: dict, missing_ok=False) -> Optional[SSOInstance]:
     start_url = scoped_config.get("sso_start_url")
     region = scoped_config.get("sso_region")
     if not (start_url and region):
@@ -66,7 +67,7 @@ def _get_instance_from_profile(profile_name, scoped_config: dict, missing_ok=Fal
     return instance
 
 def _get_all_instances_from_config(full_config: dict):
-    instances = {}
+    instances: dict = {}
     for profile_name, scoped_config in full_config.get("profiles", {}).items():
         instance = _get_instance_from_profile(profile_name, scoped_config, missing_ok=True)
         if not instance:

--- a/lib/aws_sso_lib/exceptions.py
+++ b/lib/aws_sso_lib/exceptions.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/lib/aws_sso_lib/fake_identifiers.py
+++ b/lib/aws_sso_lib/fake_identifiers.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/lib/aws_sso_lib/format.py
+++ b/lib/aws_sso_lib/format.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import numbers
 
 from .lookup import Ids

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -4,7 +4,7 @@
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF

--- a/lib/aws_sso_lib/sso.py
+++ b/lib/aws_sso_lib/sso.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/aws_sso_lib/sso.py
+++ b/lib/aws_sso_lib/sso.py
@@ -417,7 +417,7 @@ def list_available_roles(
         if isinstance(account_id, (str, numbers.Number)):
             account_id_list = [format_account_id(account_id)]
         else:
-            account_id_list = [format_account_id(v) for v in account_id]
+            account_id_list = [format_account_id(v) for v in account_id] # type: ignore
     else:
         account_id_list = None
 
@@ -467,7 +467,7 @@ def list_available_roles(
             for role in response["roleList"]:
                 role_name = role["roleName"]
 
-                yield account_id, account_name, role_name
+                yield account_id, account_name, role_name # type: ignore
 
             next_token = response.get("nextToken")
             if not next_token:

--- a/lib/aws_sso_lib/vendored_botocore/__init__.py
+++ b/lib/aws_sso_lib/vendored_botocore/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/lib/aws_sso_lib/vendored_botocore/utils.py
+++ b/lib/aws_sso_lib/vendored_botocore/utils.py
@@ -205,8 +205,11 @@ class SSOTokenFetcher(object):
                 raise PendingAuthorizationExpiredError()
             self._sleep(interval)
 
+    def _cache_key(self, start_url):
+        return hashlib.sha1(start_url.encode('utf-8')).hexdigest()
+
     def _token(self, start_url, force_refresh):
-        cache_key = hashlib.sha1(start_url.encode('utf-8')).hexdigest()
+        cache_key = self._cache_key(start_url)
         # Only obey the token cache if we are not forcing a refresh.
         if not force_refresh and cache_key in self._cache:
             token = self._cache[cache_key]
@@ -220,8 +223,18 @@ class SSOTokenFetcher(object):
     def fetch_token(self, start_url, force_refresh=False):
         return self._token(start_url, force_refresh)
 
+    def get_token_from_cache(self, start_url):
+        cache_key = self._cache_key(start_url)
+        if cache_key in self._cache:
+            token = self._cache[cache_key]
+            return token
+        return None
+
+    def is_token_expired(self, token):
+        return self._is_expired(token)
+
     def pop_token_from_cache(self, start_url):
-        cache_key = hashlib.sha1(start_url.encode('utf-8')).hexdigest()
+        cache_key = self._cache_key(start_url)
         # Only obey the token cache if we are not forcing a refresh.
         if cache_key in self._cache:
             token = self._cache[cache_key]

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -25,6 +25,8 @@ aws-error-utils = "^1.0.4"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"
+mypy = "^0.931"
+types-python-dateutil = "^2.8.7"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-sso-lib"
-version = "1.10.0" # change in aws_sso_lib/__init__.py too
+version = "1.11.0" # change in aws_sso_lib/__init__.py too
 description = "Library to make AWS SSO easier"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"

--- a/macro/template.yaml
+++ b/macro/template.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Ben Kehoe
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Parameters:


### PR DESCRIPTION
# CLI v4.28
* Log normal output to stdout ([#54](https://github.com/benkehoe/aws-sso-util/issues/54)).
* Fix short region names for GovCloud in `aws-sso-util configure populate` and `aws-sso-util configure profile` ([#55](https://github.com/benkehoe/aws-sso-util/issues/31)).
* Update `aws-sso-util login` to use `--force-refresh` for consistency with other commands (`--force` still works).
* `aws-sso-util check` now provides more information about the token cache.

# lib v1.11
* Improvements to `SSOTokenFetcher` to support better `aws-sso-util check` functionality.
* Fixed type annotations.