### PR TITLE
lib v1.13 and CLI v4.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ## `aws-sso-util`
 
+### CLI v4.30
+* `aws-sso-util login` adds `receivedAt` time to token cache entry.
+* Improved `aws-sso-util check` feedback.
+    * Displays `receivedAt` time for token if present.
+    * Validates apparently-valid cached token by attempting to list one page of available accounts.
+* Add `--check-profile` option to `aws-sso-util check` for pulling configuration from a profile.
+
 ### CLI v4.29
 * Remove support for Python 3.6 (removed in `boto3`).
 * Fix `aws-sso-credential-process` for `botocore` change.
@@ -51,6 +58,9 @@
 * Fix name fetching error with `!Ref` principal or target
 
 ## `aws-sso-lib`
+
+### lib v1.13
+* `login()` adds `receivedAt` timestamp to token dict.
 
 ### lib v1.12
 * Remove support for Python 3.6 (removed in `boto3`).

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -36,5 +36,5 @@ requests = "^2.26.0"
 pylint = "^2.5.2"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-sso-util"
-version = "4.29.0" # change in aws_sso_util/__init__.py too
+version = "4.30.0" # change in aws_sso_util/__init__.py too
 description = "Utilities to make AWS SSO easier"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ pyyaml = "^5.3.1"
 jsonschema = "^3.2.0"
 aws-error-utils = "^1.0.4"
 python-dateutil = "^2.8.1"
-aws-sso-lib = "^1.12.0"
+aws-sso-lib = "^1.13.0"
 # aws-sso-lib = { path = "../lib" }
 requests = "^2.26.0"
 

--- a/cli/src/aws_sso_util/__init__.py
+++ b/cli/src/aws_sso_util/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '4.29.0' # change in pyproject.toml too
+__version__ = '4.30.0' # change in pyproject.toml too

--- a/docs/check.md
+++ b/docs/check.md
@@ -72,3 +72,9 @@ If no roles are accessible in the account, it will print an error and exit with 
 If there are roles accessible in the account, but the given role is not accessible in the account, it will exit with return code 204.
 
 If the access is found, it will exit with return code 0 (success).
+
+## Checking a config profile
+
+To check access for a specific profile in `~/.aws/config` (or a custom config file specified with the `AWS_CONFIG_FILE` environment variable), use the `--check-profile` option.
+The profile must have the `sso_start_url`, `sso_region`, `sso_account_id`, and `sso_role_name` fields.
+You cannot use `--sso-start-url`/`-u`, `--sso-region`, `--account-id`/`-a`, and `--role-name`/`-r` when using `--check-profile`.

--- a/lib/aws_sso_lib/__init__.py
+++ b/lib/aws_sso_lib/__init__.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-__version__ = '1.12.0' # change in pyproject.toml too
+__version__ = '1.13.0' # change in pyproject.toml too
 
 from .sso import get_boto3_session, login, list_available_accounts, list_available_roles
 from .assignments import Assignment, list_assignments

--- a/lib/aws_sso_lib/sso.py
+++ b/lib/aws_sso_lib/sso.py
@@ -292,6 +292,8 @@ def login(
         force_refresh=force_refresh
     )
     token['expiresAt'] = _serialize_utc_timestamp(token['expiresAt'])
+    if 'receivedAt' in token:
+        token['receivedAt'] = _serialize_utc_timestamp(token['receivedAt'])
 
     return token
 

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -29,5 +29,5 @@ mypy = "^0.931"
 types-python-dateutil = "^2.8.7"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-sso-lib"
-version = "1.12.0" # change in aws_sso_lib/__init__.py too
+version = "1.13.0" # change in aws_sso_lib/__init__.py too
 description = "Library to make AWS SSO easier"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### CLI v4.30
* `aws-sso-util login` adds `receivedAt` time to token cache entry.
* Improved `aws-sso-util check` feedback.
    * Displays `receivedAt` time for token if present.
    * Validates apparently-valid cached token by attempting to list one page of available accounts.
* Add `--check-profile` option to `aws-sso-util check` for pulling configuration from a profile.

### lib v1.13
* `login()` adds `receivedAt` timestamp to token dict.