### PR TITLE
Don't return Suspended accounts when listing by OU

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 * [Geordam](https://github.com/Geordam)
 * [Imran](https://github.com/fai555)
 * [O'Shaughnessy Evans](https://github.com/oshaughnessy)
+* [Anthony Engelstad](https://github.com/anton0)

--- a/cli/src/aws_sso_util/cfn.py
+++ b/cli/src/aws_sso_util/cfn.py
@@ -233,7 +233,8 @@ def process_config(
         ou_fetcher = lambda ou, recursive: lookup.lookup_accounts_for_ou(session, ou,
             recursive=recursive,
             cache=cache,
-            exclude_org_mgmt_acct=True)
+            exclude_org_mgmt_acct=True,
+            exclude_inactive_accts=True)
 
         resource_collection = resources.get_resources_from_config(
             config,

--- a/cli/src/aws_sso_util/cfn_lib/macro.py
+++ b/cli/src/aws_sso_util/cfn_lib/macro.py
@@ -105,7 +105,8 @@ def process_template(template,
     ou_fetcher = lambda ou, recursive: lookup.lookup_accounts_for_ou(session, ou,
             recursive=recursive,
             cache=ou_accounts_cache,
-            exclude_org_mgmt_acct=True)
+            exclude_org_mgmt_acct=True,
+            exclude_inactive_accts=True)
 
     for resource_name, config in configs.items():
         resource_collection = resources.get_resources_from_config(

--- a/docs/cloudformation.md
+++ b/docs/cloudformation.md
@@ -28,6 +28,8 @@ To allow for more assignments, you need to specify a number of child stacks.
 You can either specify the number of child stacks explicitly, or provide the maximum number of assignment resources you want to support (which will calculate the number of child stacks automatically).
 See below for how to configure this.
 
+When specifying an OU for assignment the generated assignments will not include accounts with a status of `SUSPENDED` or `PENDING_CLOSURE`, these accounts can be explicitly listed.
+
 Note that no assignments for the Organizations management account will be generated unless it is explicitly listed as an account target.
 If an OU that contains the management account is given as a target, the generated assignments for that OU will not include the management account.
 

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -544,7 +544,7 @@ def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None,
             LOGGER.debug(f"ListAccountsPage page {ind+1} for {ou}: {', '.join(acct_strs)}")
             for account in response["Accounts"]:
                 cache[ou_accounts_key].append(account)
-                if account["Status"] != "ACTIVE" and exclude_inactive_accts is True:
+                if exclude_inactive_accts and account["Status"] != "ACTIVE":
                     LOGGER.debug(f"Skipping {account['Status']} account {account['Id']}")
                     continue
                 if org_mgmt_acct and account["Id"] == org_mgmt_acct:

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -505,7 +505,7 @@ def lookup_account_by_name(session, account_name, *, cache=None):
 
 _DESCRIBE_ORGANIZATION_CACHE_KEY = "describe_organization"
 
-def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None, exclude_org_mgmt_acct=False):
+def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None, exclude_org_mgmt_acct=False, exclude_inactive_accts=False):
     if cache is None:
         cache = {}
 
@@ -543,10 +543,10 @@ def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None,
             acct_strs = [_acct_str(a) for a in response["Accounts"]]
             LOGGER.debug(f"ListAccountsPage page {ind+1} for {ou}: {', '.join(acct_strs)}")
             for account in response["Accounts"]:
-                if account["Status"] != "ACTIVE":
+                cache[ou_accounts_key].append(account)
+                if account["Status"] != "ACTIVE" and exclude_inactive_accts is True:
                     LOGGER.debug(f"Skipping {account['Status']} account {account['Id']}")
                     continue
-                cache[ou_accounts_key].append(account)
                 if org_mgmt_acct and account["Id"] == org_mgmt_acct:
                     continue
                 yield account

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -543,6 +543,9 @@ def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None,
             acct_strs = [_acct_str(a) for a in response["Accounts"]]
             LOGGER.debug(f"ListAccountsPage page {ind+1} for {ou}: {', '.join(acct_strs)}")
             for account in response["Accounts"]:
+                if account["Status"] != "ACTIVE":
+                    LOGGER.debug(f"Skipping {account['Status']} account {account['Id']}")
+                    continue
                 cache[ou_accounts_key].append(account)
                 if org_mgmt_acct and account["Id"] == org_mgmt_acct:
                     continue


### PR DESCRIPTION
The boto call [list_accounts_for_parent](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations.html#Organizations.Client.list_accounts_for_parent) includes accounts in with statuses `'ACTIVE'|'SUSPENDED'|'PENDING_CLOSURE'`

However assignments cannot be deployed to accounts in the `SUSPENDED` state, trying to results in Cloudformation stalling and eventually returning an error when using the macro:

```
Resource handler returned message: "Error occurred during operation 'Request REDACTED failed due to: 
AWS SSO is unable to complete your request at this time. 
Obtaining permissions to manage your AWS account 'REDACTED' is taking longer than usual.
```

Worth noting the same behavior occurs in the SSO web ui - you are permitted to begin creating the assignment, then it hangs on processing until eventually timing out

I'm not sure if there's a use case for deploying assignments to an account in `PENDING_CLOSURE` nor do I have an account to test that with, but it's easy enough to return those as well if you think it's worth allowing.

I'm only using the macro, but I have tested against our accounts and this works as expected.

Resolves #80 hopefully :crossed_fingers: 