### PR TITLE
Release CLI v4.31 and lib v1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-`aws-sso-util` and `aws-sso-lib` use [monotonic versioning](blog.appliedcompscilab.com/monotonic_versioning_manifesto/).
+`aws-sso-util` and `aws-sso-lib` use [monotonic versioning](https://github.com/benkehoe/monotonic-versioning-manifesto).
 
 * [`aws-sso-util`](#aws-sso-util)
 * [`aws-sso-lib`](#aws-sso-lib)
 
 ## `aws-sso-util`
+
+### CLI v4.31
+* CloudFormation functionality now excludes suspended accounts from OU traversal ([#80](https://github.com/benkehoe/aws-sso-util/issues/80) via [#81](https://github.com/benkehoe/aws-sso-util/pull/81)).
+* Upgrade to `click` 8 ([#85](https://github.com/benkehoe/aws-sso-util/issues/85)).
 
 ### CLI v4.30
 * `aws-sso-util login` adds `receivedAt` time to token cache entry.
@@ -58,6 +62,9 @@
 * Fix name fetching error with `!Ref` principal or target
 
 ## `aws-sso-lib`
+
+### lib v1.14
+* Add `exclude_inactive_accts` parameter to `lookup_accounts_for_ou()` ([#80](https://github.com/benkehoe/aws-sso-util/issues/80) via [#81](https://github.com/benkehoe/aws-sso-util/pull/81)).
 
 ### lib v1.13
 * `login()` adds `receivedAt` timestamp to token dict.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 * [Geordam](https://github.com/Geordam)
 * [Imran](https://github.com/fai555)
 * [O'Shaughnessy Evans](https://github.com/oshaughnessy)
+* [Anthony Engelstad](https://github.com/anton0)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-sso-util"
-version = "4.30.0" # change in aws_sso_util/__init__.py too
+version = "4.31.0" # change in aws_sso_util/__init__.py too
 description = "Utilities to make AWS SSO easier"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -22,11 +22,11 @@ aws-sso-util = 'aws_sso_util.cli:cli'
 [tool.poetry.dependencies]
 python = "^3.7"
 # botocore = {git = "https://github.com/boto/botocore.git", rev = "v2"}
-click = "^7.1.2"
+click = ">=8.0.0, < 9.0.0"
 boto3 = ">=1.24.60, <2.0.0"
 pyyaml = "^5.3.1"
 jsonschema = "^3.2.0"
-aws-error-utils = "^1.0.4"
+aws-error-utils = "^2.4"
 python-dateutil = "^2.8.1"
 aws-sso-lib = "^1.13.0"
 # aws-sso-lib = { path = "../lib" }

--- a/cli/src/aws_sso_util/__init__.py
+++ b/cli/src/aws_sso_util/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '4.30.0' # change in pyproject.toml too
+__version__ = '4.31.0' # change in pyproject.toml too

--- a/cli/src/aws_sso_util/cfn.py
+++ b/cli/src/aws_sso_util/cfn.py
@@ -233,7 +233,8 @@ def process_config(
         ou_fetcher = lambda ou, recursive: lookup.lookup_accounts_for_ou(session, ou,
             recursive=recursive,
             cache=cache,
-            exclude_org_mgmt_acct=True)
+            exclude_org_mgmt_acct=True,
+            exclude_inactive_accts=True)
 
         resource_collection = resources.get_resources_from_config(
             config,

--- a/cli/src/aws_sso_util/cfn_lib/macro.py
+++ b/cli/src/aws_sso_util/cfn_lib/macro.py
@@ -105,7 +105,8 @@ def process_template(template,
     ou_fetcher = lambda ou, recursive: lookup.lookup_accounts_for_ou(session, ou,
             recursive=recursive,
             cache=ou_accounts_cache,
-            exclude_org_mgmt_acct=True)
+            exclude_org_mgmt_acct=True,
+            exclude_inactive_accts=True)
 
     for resource_name, config in configs.items():
         resource_collection = resources.get_resources_from_config(

--- a/docs/cloudformation.md
+++ b/docs/cloudformation.md
@@ -28,6 +28,8 @@ To allow for more assignments, you need to specify a number of child stacks.
 You can either specify the number of child stacks explicitly, or provide the maximum number of assignment resources you want to support (which will calculate the number of child stacks automatically).
 See below for how to configure this.
 
+When specifying an OU for assignment the generated assignments will not include accounts with a status of `SUSPENDED` or `PENDING_CLOSURE`, these accounts can be explicitly listed.
+
 Note that no assignments for the Organizations management account will be generated unless it is explicitly listed as an account target.
 If an OU that contains the management account is given as a target, the generated assignments for that OU will not include the management account.
 

--- a/lib/aws_sso_lib/__init__.py
+++ b/lib/aws_sso_lib/__init__.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-__version__ = '1.13.0' # change in pyproject.toml too
+__version__ = '1.14.0' # change in pyproject.toml too
 
 from .sso import get_boto3_session, login, list_available_accounts, list_available_roles
 from .assignments import Assignment, list_assignments

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -544,7 +544,7 @@ def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None,
             LOGGER.debug(f"ListAccountsPage page {ind+1} for {ou}: {', '.join(acct_strs)}")
             for account in response["Accounts"]:
                 cache[ou_accounts_key].append(account)
-                if account["Status"] != "ACTIVE" and exclude_inactive_accts is True:
+                if exclude_inactive_accts and account["Status"] != "ACTIVE":
                     LOGGER.debug(f"Skipping {account['Status']} account {account['Id']}")
                     continue
                 if org_mgmt_acct and account["Id"] == org_mgmt_acct:

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -505,7 +505,7 @@ def lookup_account_by_name(session, account_name, *, cache=None):
 
 _DESCRIBE_ORGANIZATION_CACHE_KEY = "describe_organization"
 
-def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None, exclude_org_mgmt_acct=False):
+def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None, exclude_org_mgmt_acct=False, exclude_inactive_accts=False):
     if cache is None:
         cache = {}
 
@@ -543,10 +543,10 @@ def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None,
             acct_strs = [_acct_str(a) for a in response["Accounts"]]
             LOGGER.debug(f"ListAccountsPage page {ind+1} for {ou}: {', '.join(acct_strs)}")
             for account in response["Accounts"]:
-                if account["Status"] != "ACTIVE":
+                cache[ou_accounts_key].append(account)
+                if account["Status"] != "ACTIVE" and exclude_inactive_accts is True:
                     LOGGER.debug(f"Skipping {account['Status']} account {account['Id']}")
                     continue
-                cache[ou_accounts_key].append(account)
                 if org_mgmt_acct and account["Id"] == org_mgmt_acct:
                     continue
                 yield account

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -543,6 +543,9 @@ def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None,
             acct_strs = [_acct_str(a) for a in response["Accounts"]]
             LOGGER.debug(f"ListAccountsPage page {ind+1} for {ou}: {', '.join(acct_strs)}")
             for account in response["Accounts"]:
+                if account["Status"] != "ACTIVE":
+                    LOGGER.debug(f"Skipping {account['Status']} account {account['Id']}")
+                    continue
                 cache[ou_accounts_key].append(account)
                 if org_mgmt_acct and account["Id"] == org_mgmt_acct:
                     continue

--- a/lib/aws_sso_lib/lookup.py
+++ b/lib/aws_sso_lib/lookup.py
@@ -545,7 +545,7 @@ def lookup_accounts_for_ou(session, ou, *, recursive, refresh=False, cache=None,
             for account in response["Accounts"]:
                 cache[ou_accounts_key].append(account)
                 if exclude_inactive_accts and account["Status"] != "ACTIVE":
-                    LOGGER.debug(f"Skipping {account['Status']} account {account['Id']}")
+                    LOGGER.debug(f"Skipping account {account['Id']}: {account['Status']}")
                     continue
                 if org_mgmt_acct and account["Id"] == org_mgmt_acct:
                     continue

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 python = "^3.7"
 # botocore = {git = "https://github.com/boto/botocore.git", rev = "v2"}
 boto3 = ">=1.24.60, <2.0.0"
-aws-error-utils = "^1.0.4"
+aws-error-utils = "^2.4"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-sso-lib"
-version = "1.13.0" # change in aws_sso_lib/__init__.py too
+version = "1.14.0" # change in aws_sso_lib/__init__.py too
 description = "Library to make AWS SSO easier"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### CLI v4.31
* CloudFormation functionality now excludes suspended accounts from OU traversal ([#80](https://github.com/benkehoe/aws-sso-util/issues/80) via [#81](https://github.com/benkehoe/aws-sso-util/pull/81)).
* Upgrade to `click` 8 ([#85](https://github.com/benkehoe/aws-sso-util/issues/85)).

### lib v1.14
* Add `exclude_inactive_accts` parameter to `lookup_accounts_for_ou()` ([#80](https://github.com/benkehoe/aws-sso-util/issues/80) via [#81](https://github.com/benkehoe/aws-sso-util/pull/81)).