### PR TITLE
Autofill Authorization Code in login URL

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 * [Imran](https://github.com/fai555)
 * [O'Shaughnessy Evans](https://github.com/oshaughnessy)
 * [Anthony Engelstad](https://github.com/anton0)
+* [Shaun Dewberry](https://github.com/shaundewberry)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -28,8 +28,8 @@ pyyaml = "^5.3.1"
 jsonschema = "^3.2.0"
 aws-error-utils = "^2.4"
 python-dateutil = "^2.8.1"
-aws-sso-lib = "^1.13.0"
-# aws-sso-lib = { path = "../lib" }
+# aws-sso-lib = "^1.13.0"
+aws-sso-lib = { path = "../lib", develop = true }
 requests = "^2.26.0"
 
 [tool.poetry.dev-dependencies]

--- a/cli/src/aws_sso_util/cli.py
+++ b/cli/src/aws_sso_util/cli.py
@@ -15,64 +15,64 @@ import click
 
 from . import __version__
 
-from .assignments import assignments
-from .cfn import generate_template
-from .check import check
-from .configure_profile import configure_profile
-from .credential_process import credential_process
-from .deploy_macro import deploy_macro
+# from .assignments import assignments
+# from .cfn import generate_template
+# from .check import check
+# from .configure_profile import configure_profile
+# from .credential_process import credential_process
+# from .deploy_macro import deploy_macro
 from .login import login
-from .logout import logout
-from .lookup import lookup
-from .populate_profiles import populate_profiles
-from .roles import roles
-from .run_as import run_as
-from .console import launch, get_config_token, launch_from_config
+# from .logout import logout
+# from .lookup import lookup
+# from .populate_profiles import populate_profiles
+# from .roles import roles
+# from .run_as import run_as
+# from .console import launch, get_config_token, launch_from_config
 
 @click.group(name="aws-sso-util")
 @click.version_option(version=__version__, message='%(version)s')
 def cli():
     pass
 
-@cli.group()
-def configure():
-    """Commands to set up ~/.aws/config."""
-    pass
+# @cli.group()
+# def configure():
+#     """Commands to set up ~/.aws/config."""
+#     pass
 
-configure.add_command(configure_profile, "profile")
-configure.add_command(populate_profiles, "populate")
+# configure.add_command(configure_profile, "profile")
+# configure.add_command(populate_profiles, "populate")
 
 cli.add_command(login)
-cli.add_command(logout)
-cli.add_command(roles)
-cli.add_command(check)
-cli.add_command(run_as)
+# cli.add_command(logout)
+# cli.add_command(roles)
+# cli.add_command(check)
+# cli.add_command(run_as)
 
-@cli.group()
-def console():
-    """Commands for launching the AWS console in a browser."""
-    pass
+# @cli.group()
+# def console():
+#     """Commands for launching the AWS console in a browser."""
+#     pass
 
-console.add_command(launch)
-console.add_command(get_config_token)
-console.add_command(launch_from_config)
+# console.add_command(launch)
+# console.add_command(get_config_token)
+# console.add_command(launch_from_config)
 
-@cli.group()
-def admin():
-    """Commands for IAM Identity Center administration."""
-    pass
+# @cli.group()
+# def admin():
+#     """Commands for IAM Identity Center administration."""
+#     pass
 
-admin.add_command(lookup)
-admin.add_command(assignments)
+# admin.add_command(lookup)
+# admin.add_command(assignments)
 
-# admin.add_command(deploy_macro)
-admin.add_command(generate_template, "cfn")
+# # admin.add_command(deploy_macro)
+# admin.add_command(generate_template, "cfn")
 
-cli.add_command(credential_process)
+# cli.add_command(credential_process)
 
-_list_commands = cli.list_commands
-def list_commands(ctx):
-    return [c for c in _list_commands(ctx) if c != "credential-process"]
+# _list_commands = cli.list_commands
+# def list_commands(ctx):
+#     return [c for c in _list_commands(ctx) if c != "credential-process"]
 
-cli.list_commands = list_commands
+# cli.list_commands = list_commands
 

--- a/cli/src/aws_sso_util/login.py
+++ b/cli/src/aws_sso_util/login.py
@@ -13,6 +13,7 @@
 
 import os
 import sys
+import json
 import logging
 
 import botocore
@@ -23,7 +24,20 @@ import click
 
 import aws_error_utils
 
-from aws_sso_lib.config import find_instances, find_all_instances, SSOInstance
+from aws_sso_lib.config import (
+    Specifier,
+    Session,
+    Source,
+    get_specifier,
+    find_all_sessions,
+    get_session_from_config_profile,
+    get_session_from_config_session,
+    InlineSessionError,
+    ConfigProfileError,
+    ConfigSessionError,
+    NotAnSSOProfileError
+)
+
 from aws_sso_lib.sso import get_token_fetcher
 from aws_sso_lib.exceptions import PendingAuthorizationExpiredError
 
@@ -40,10 +54,11 @@ UTC_TIME_FORMAT = "%Y-%m-%d %H:%M UTC"
 LOCAL_TIME_FORMAT = "%Y-%m-%d %H:%M %Z"
 
 @click.command()
-@click.argument("sso_start_url", required=False)
+@click.argument("specifier", required=False)
 @click.argument("sso_region", required=False)
-@click.option("--profile", metavar="PROFILE_NAME", help="Use a profile to specify Identity Center instance")
-@click.option("--all", "login_all", is_flag=True, default=None, help="Log in to all Identity Center instances if multiple are found")
+@click.option("--profile", metavar="PROFILE_NAME", help="Use a config profile to specify Identity Center session")
+@click.option("--sso-session", metavar="SESSION_NAME", help="Use a config session to specify Identity Center session")
+@click.option("--all", "login_all", is_flag=True, default=None, help="Scan for all Identity Center sessions and log in to them all")
 @click.option("--force-refresh", "force", is_flag=True, help="Force re-authentication")
 @click.option("--headless", is_flag=True, default=None, help="Never open a browser window")
 @click.option("--verbose", "-v", count=True)
@@ -51,9 +66,10 @@ LOCAL_TIME_FORMAT = "%Y-%m-%d %H:%M %Z"
 @click.option("--sso-region", "alternate_sso_region", hidden=True)
 @click.option("--force", "alternate_force", is_flag=True, hidden=True)
 def login(
-        sso_start_url,
+        specifier,
         sso_region,
         profile,
+        sso_session,
         login_all,
         force,
         headless,
@@ -61,7 +77,7 @@ def login(
         alternate_sso_start_url,
         alternate_sso_region,
         alternate_force):
-    """Log in to an Identity Center instance.
+    """Log in to an Identity Center session.
 
     Note this only needs to be done once for a given Identity Center instance (i.e., start URL),
     as all profiles sharing the same start URL will share the same login.
@@ -73,10 +89,23 @@ def login(
     Otherwise, you can provide a full start URL, or a regex for the start URL (usually a substring will work),
     and if this uniquely identifies a start URL in your config, that will suffice.
 
-    You can also provide a profile name with --profile to use the Identity Center instance from a specific profile.
+    You can also provide a profile name with --profile to use the Identity Center session from a specific config profile,
+    or --sso-session for a specific config session.
     """
-    sso_start_url = sso_start_url or alternate_sso_start_url
+    specifier_param = specifier
+    sso_start_url = specifier_param or alternate_sso_start_url
     sso_region = sso_region or alternate_sso_region
+    
+    # mutually exclusive options
+    if sso_start_url and profile:
+        raise click.BadParameter("Cannot use specifier and --profile")
+    
+    if sso_start_url and sso_session:
+        raise click.BadParameter("Cannot use specifier and --sso-session")
+    
+    if profile and sso_session:
+        raise click.BadParameter("Cannot use --profile and --sso-session")
+
     force = force or alternate_force
 
     if login_all is None:
@@ -84,55 +113,127 @@ def login(
 
     configure_logging(LOGGER, verbose)
 
-    if login_all:
-        instances, _ = find_all_instances(
-            start_url_vars=LOGIN_DEFAULT_START_URL_VARS,
-            region_vars=LOGIN_DEFAULT_SSO_REGION_VARS,
-        )
-    else:
-        instances, specifier, all_instances = find_instances(
-            profile_name=profile,
-            profile_source="--profile",
-            start_url=sso_start_url,
-            start_url_source="CLI input",
-            region=sso_region,
-            region_source="CLI input",
-            start_url_vars=LOGIN_DEFAULT_START_URL_VARS,
-            region_vars=LOGIN_DEFAULT_SSO_REGION_VARS,
-        )
-
-        if not instances:
-            if all_instances:
-                LOGGER.fatal((
-                    f"No Identity Center config matched {specifier.to_str(region=True)} " +
-                    f"from {SSOInstance.to_strs(all_instances)}"))
-            else:
-                LOGGER.fatal("No Identity Center config found")
-            sys.exit(1)
-
-        if len(instances) > 1:
-            LOGGER.fatal(f"Found {len(instances)} Identity Center configs, please specify one or use --all: {SSOInstance.to_strs(instances)}")
-            sys.exit(1)
-
-    LOGGER.debug(f"Instances: {SSOInstance.to_strs(instances)}")
-
-    session = botocore.session.Session(session_vars={
-        'profile': (None, None, None, None),
-        'region': (None, None, None, None),
+    botocore_session = botocore.session.Session(session_vars={
+        "profile": (None, None, None, None),
+        "region": (None, None, None, None),
     })
 
-    regions = set(i.region for i in instances)
+    # first check if we've got specific config to get the session from
+    # either a config profile or a config session, resulting in a list
+    # of just a single session
+    if profile:
+        try:
+            sessions = [get_session_from_config_profile(
+                profile_name=profile,
+                source=Source(type="CLI parameter", name="--profile"),
+                botocore_session_full_config=botocore_session.full_config
+            )]
+        except NotAnSSOProfileError as e:
+            LOGGER.fatal(str(e))
+            sys.exit(5)
+        except ConfigProfileError as e:
+            LOGGER.fatal(str(e))
+            sys.exit(5)
+    elif sso_session:
+        try:
+            sessions = [get_session_from_config_session(
+                session_name=sso_session,
+                source=Source(type="CLI parameter", name="--sso-session"),
+                botocore_session_full_config=botocore_session.full_config
+            )]
+        except ConfigSessionError as e:
+            LOGGER.fatal(str(e))
+            sys.exit(5)
+    else:
+        # otherwise we need to search
+
+        if login_all:
+            specifier = None
+        else:
+            # the specifier might come from params
+            if sso_start_url and sso_start_url.startswith("http") and sso_region:
+                if alternate_sso_start_url or alternate_sso_region:
+                    source_name = "--sso-start-url and --sso-region"
+                else:
+                    source_name = "positional parameters"
+                specifier = Specifier(
+                    value=json.dumps({
+                        "sso_start_url": sso_start_url,
+                        "sso_region": sso_region
+                    }),
+                    source=Source(
+                        type="CLI parameter",
+                        name=source_name
+                    ))
+            elif specifier_param:
+                if alternate_sso_start_url:
+                    source_name = "--sso-start-url"
+                else:
+                    source_name = "positional parameter"
+                try:
+                    specifier = Specifier(
+                        value=specifier_param,
+                        source=Source(
+                            type="CLI parameter",
+                            name=source_name
+                        ))
+                except InlineSessionError as e:
+                    LOGGER.fatal(str(e))
+                    sys.exit(5)
+            else:
+                try:
+                    specifier = get_specifier()
+                except InlineSessionError as e:
+                    LOGGER.fatal(str(e))
+                    sys.exit(5)
+
+        if specifier.session:
+            sessions = [specifier.session]
+        else:
+            all_sessions = find_all_sessions()
+
+            if not all_sessions.unique_sessions:
+                message = "No valid Identity Center sessions found"
+                if all_sessions.malformed_session_errors:
+                    message = (
+                        message
+                        + ", "
+                        + f"but {len(all_sessions.malformed_session_errors)} invalid sessions were found"
+                        + ": "
+                        + "; ".join(str(e) for e in all_sessions.malformed_session_errors)
+                    )
+                LOGGER.fatal(message)
+                sys.exit(1)
+            
+            if not specifier:
+                sessions = list(all_sessions.unique_sessions.values())
+            else:
+                sessions = list(all_sessions.filter(specifier).values())
+                if not sessions:
+                    LOGGER.fatal(f"No Identity Center sessions matched specifier {specifier} from {all_sessions}")
+                    sys.exit(1)
+
+    if not login_all and len(sessions) > 1:
+        LOGGER.fatal(f"Found {len(sessions)} Identity Center sessions, please specify one or use --all: {sessions}")
+        sys.exit(1)
+
+    LOGGER.debug(f"Sessions: {sessions}")
+
+    regions = set(s.region for s in sessions)
     token_fetchers = {}
     for region in regions:
-        token_fetchers[region] = get_token_fetcher(session, region, interactive=True, disable_browser=headless)
+        token_fetchers[region] = get_token_fetcher(botocore_session, region, interactive=True, disable_browser=headless)
 
-    if len(instances) > 1:
-        LOGGER.info(f"Logging in {len(instances)} Identity Center instances")
-    for instance in instances:
-        LOGGER.info(f"Logging in {instance.start_url}")
-        token_fetcher = token_fetchers[instance.region]
+    if len(sessions) > 1:
+        LOGGER.info(f"Logging in {len(sessions)} Identity Center sessions")
+    for session in sessions:
+        if session.is_inline_session():
+            LOGGER.info(f"Logging in {session.start_url}")
+        else:
+            LOGGER.info(f"Logging in {session.session_name} ({session.start_url})")
+        token_fetcher = token_fetchers[session.region]
         try:
-            token = token_fetcher.fetch_token(instance.start_url, force_refresh=force)
+            token = token_fetcher.fetch_token(session.start_url, force_refresh=force)
             LOGGER.debug(f"Token: {token}")
             expiration = token['expiresAt']
             if isinstance(expiration, str):

--- a/cli/src/aws_sso_util/utils.py
+++ b/cli/src/aws_sso_util/utils.py
@@ -15,7 +15,7 @@ import logging
 import logging.handlers
 import sys
 
-from aws_sso_lib.config import find_instances, SSOInstance
+# from aws_sso_lib.config import find_instances, SSOInstance
 
 class StdoutFilter(logging.Filter):
     def filter(self, rec):
@@ -71,30 +71,30 @@ def configure_logging(logger, verbose, **config_args):
 class GetInstanceError(Exception):
     pass
 
-def get_instance(sso_start_url, sso_region, sso_start_url_vars=None, sso_region_vars=None):
-    instances, specifier, all_instances = find_instances(
-        profile_name=None,
-        profile_source=None,
-        start_url=sso_start_url,
-        start_url_source="CLI input",
-        region=sso_region,
-        region_source="CLI input",
-        start_url_vars=sso_start_url_vars,
-        region_vars=sso_region_vars
-    )
+# def get_instance(sso_start_url, sso_region, sso_start_url_vars=None, sso_region_vars=None):
+#     instances, specifier, all_instances = find_instances(
+#         profile_name=None,
+#         profile_source=None,
+#         start_url=sso_start_url,
+#         start_url_source="CLI input",
+#         region=sso_region,
+#         region_source="CLI input",
+#         start_url_vars=sso_start_url_vars,
+#         region_vars=sso_region_vars
+#     )
 
-    if not instances:
-        if all_instances:
-            raise GetInstanceError(
-                f"No Identity Center instance matched {specifier.to_str(region=True)} " +
-                f"from {SSOInstance.to_strs(all_instances)}")
-        else:
-            raise GetInstanceError("No Identity Center instance found")
+#     if not instances:
+#         if all_instances:
+#             raise GetInstanceError(
+#                 f"No Identity Center instance matched {specifier.to_str(region=True)} " +
+#                 f"from {SSOInstance.to_strs(all_instances)}")
+#         else:
+#             raise GetInstanceError("No Identity Center instance found")
 
-    if len(instances) > 1:
-        raise GetInstanceError(f"Found {len(instances)} Identity Center instances, please specify one: {SSOInstance.to_strs(instances)}")
+#     if len(instances) > 1:
+#         raise GetInstanceError(f"Found {len(instances)} Identity Center instances, please specify one: {SSOInstance.to_strs(instances)}")
 
-    return instances[0]
+#     return instances[0]
 
 class Printer:
     def __init__(self, *,

--- a/lib/README.md
+++ b/lib/README.md
@@ -51,7 +51,7 @@ If the user is logged in and `force_refresh` is `False`, no action is taken.
 
 Normally, it will attempt to automatically open the user's browser to log in, as well as printing the URL and code to stderr as a fallback. However, if `disable_browser` is `True`, or if `disable_browser` is `None` (the default) and the environment variable `AWS_SSO_DISABLE_BROWSER` is set to `1` or `true`, only the message with the URL and code will be printed.
 
-A custom message can be printed by setting message to a template string using any or all of {url}, {code}, and {urlWithCode} as placeholders.
+A custom message can be printed by setting message to a template string using any or all of `{url}`, `{code}`, and `{urlWithCode}` as placeholders.
 The message can be suppressed by setting `message` to `False`.
 
 To fully control the communication with the user, use the `user_auth_handler` parameter.

--- a/lib/README.md
+++ b/lib/README.md
@@ -51,7 +51,7 @@ If the user is logged in and `force_refresh` is `False`, no action is taken.
 
 Normally, it will attempt to automatically open the user's browser to log in, as well as printing the URL and code to stderr as a fallback. However, if `disable_browser` is `True`, or if `disable_browser` is `None` (the default) and the environment variable `AWS_SSO_DISABLE_BROWSER` is set to `1` or `true`, only the message with the URL and code will be printed.
 
-A custom message can be printed by setting `message` to a template string using `{url}` and `{code}` as placeholders.
+A custom message can be printed by setting message to a template string using any or all of {url}, {code}, and {urlWithCode} as placeholders.
 The message can be suppressed by setting `message` to `False`.
 
 To fully control the communication with the user, use the `user_auth_handler` parameter.

--- a/lib/README.md
+++ b/lib/README.md
@@ -51,7 +51,7 @@ If the user is logged in and `force_refresh` is `False`, no action is taken.
 
 Normally, it will attempt to automatically open the user's browser to log in, as well as printing the URL and code to stderr as a fallback. However, if `disable_browser` is `True`, or if `disable_browser` is `None` (the default) and the environment variable `AWS_SSO_DISABLE_BROWSER` is set to `1` or `true`, only the message with the URL and code will be printed.
 
-A custom message can be printed by setting message to a template string using any or all of `{url}`, `{code}`, and `{urlWithCode}` as placeholders.
+A custom message can be printed by setting `message` to a template string using any or all of `{url}`, `{code}`, and `{urlWithCode}` as placeholders.
 The message can be suppressed by setting `message` to `False`.
 
 To fully control the communication with the user, use the `user_auth_handler` parameter.

--- a/lib/aws_sso_lib/browser.py
+++ b/lib/aws_sso_lib/browser.py
@@ -29,6 +29,9 @@ authorize this request, open the following URL:
 Then enter the code:
 
 {code}
+
+Alternatively, you may visit the following URL which will autofill the code upon loading:
+{urlWithCode}
 """)
 
 DEFAULT_NO_BROWSER_MESSAGE = textwrap.dedent("""\
@@ -40,6 +43,9 @@ Open the following URL in a browser:
 Then enter the code:
 
 {code}
+
+Alternatively, you may visit the following URL which will autofill the code upon loading:
+{urlWithCode}
 """)
 
 class OpenBrowserHandler(object):
@@ -71,7 +77,9 @@ class OpenBrowserHandler(object):
                 url=verificationUri,
                 code=userCode,
                 verificationUri=verificationUri,
-                userCode=userCode
+                userCode=userCode,
+                urlWithCode=verificationUriComplete,
+                verificationUriComplete=verificationUriComplete
             )
 
             print(message, file=self._outfile)

--- a/lib/aws_sso_lib/browser.py
+++ b/lib/aws_sso_lib/browser.py
@@ -31,6 +31,7 @@ Then enter the code:
 {code}
 
 Alternatively, you may visit the following URL which will autofill the code upon loading:
+
 {urlWithCode}
 """)
 
@@ -45,6 +46,7 @@ Then enter the code:
 {code}
 
 Alternatively, you may visit the following URL which will autofill the code upon loading:
+
 {urlWithCode}
 """)
 

--- a/lib/aws_sso_lib/config.py
+++ b/lib/aws_sso_lib/config.py
@@ -14,265 +14,307 @@
 import os
 import logging
 import re
+import json
 from collections import namedtuple
-from typing import Optional
+from dataclasses import dataclass, field as dataclass_field
+from typing import Optional, Union
 
 import botocore
 from botocore.exceptions import ProfileNotFound
+from .vendored_awscli.utils import parse_sso_registration_scopes
 
 LOGGER = logging.getLogger(__name__)
 
-def _get(names):
+def _getenv(names: list[str]):
     for name in names:
         value = os.environ.get(name)
         if value:
             return value, name
     return None, None
 
-START_URL_VARS = ["AWS_DEFAULT_SSO_START_URL"]
-REGION_VARS    = ["AWS_DEFAULT_SSO_REGION"]
+SPECIFIER_VARS = ["AWS_SSO_SESSION"]
 
-class SSOInstance(namedtuple("SSOInstance", ["start_url", "region", "start_url_source", "region_source"])):
-    def to_str(self, region=None):
-        if region is None:
-            region_str = "[NO_REGION]" if not self.region else ""
-        elif region:
-            region_str = f"[{self.region}]"
-        else:
-            region_str = ""
-        return f"{self.start_url}{region_str}"
+@dataclass(frozen=True)
+class Source:
+    type: str
+    name: str
+    parent: Optional["Source"] = None
 
-    def __eq__(self, other):
-        return self.start_url == other.start_url and self.region == other.region
+@dataclass(frozen=True)
+class Session:
+    session_name: str
+    source: Source
 
-    def __str__(self):
-        return self.to_str()
+    start_url: str
+    region: str
+    registration_scopes: Optional[list[str]] = None
 
-    def __bool__(self):
-        return bool(self.start_url) or bool(self.region)
+    def is_inline_session(self):
+        return self.session_name.startswith("http")
 
-    @classmethod
-    def to_strs(cls, instances, region=None):
-        return ", ".join(i.to_str(region=region) for i in instances)
+class InlineSessionError(Exception):
+    pass
 
-def _get_instance_from_profile(profile_name, scoped_config: dict, missing_ok=False) -> Optional[SSOInstance]:
-    start_url = scoped_config.get("sso_start_url")
-    region = scoped_config.get("sso_region")
-    if not (start_url and region):
-        if not missing_ok:
-            LOGGER.debug(f"Did not find config in profile {profile_name}")
+@dataclass(frozen=True)
+class Specifier:
+    value: str
+    source: Source
+
+    session: Optional[Session] = dataclass_field(init=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "session", self._to_session())
+
+    def _to_session(self) -> Optional[Session]:
+        if not self.value.strip().startswith("{"):
+            return None
+        try:
+            session_data = json.loads(self.value)
+        except json.JSONDecodeError as e:
+            raise InlineSessionError(f"Inline session is not valid JSON")
+        if not isinstance(session_data, dict):
+            return None
+
+        missing = []
+        if "sso_start_url" not in session_data:
+            missing.append("sso_start_url")
+        if "sso_region" not in session_data:
+            missing.append("sso_region")
+        
+        if missing:
+            raise InlineSessionError(f"Inline session in specifier is missing fields: {' '.join(missing)}")
+        
+        session_kwargs = {
+            "session_name": session_data["sso_start_url"], #TODO: allow this to given in the session_data?
+            "source": Source(
+                type="inline specifier",
+                name=self.source.name,
+                parent=self.source
+            ),
+            "start_url": session_data["sso_start_url"],
+            "region": session_data["sso_region"]
+        }
+
+        if "sso_registration_scopes" in session_data:
+            raw_registration_scopes = session_data["sso_registration_scopes"]
+            try:
+                session_kwargs["registration_scopes"] = parse_sso_registration_scopes(raw_registration_scopes)
+            except Exception as e:
+                raise (f"Inline session has malformed registration scopes {raw_registration_scopes}")
+        
+        return Session(**session_kwargs)
+    
+    def matches(self, session: Session) -> bool:
+        if self.session:
+            raise TypeError("This specifier is in an inline session, it can't be used for matching")
+        if self.value.startswith("http"):
+            return self.value == session.start_url
+        return re.search(self.value, session.session_name)
+
+def get_specifier() -> Specifier:
+    value, name = _getenv(SPECIFIER_VARS)
+    if not value:
         return None
-    instance = SSOInstance(start_url, region, "profile", "profile")
-    LOGGER.debug(f"Profile {profile_name} has instance {instance.to_str(region=True)}")
-    return instance
-
-def _get_all_instances_from_config(full_config: dict):
-    instances: dict = {}
-    for profile_name, scoped_config in full_config.get("profiles", {}).items():
-        instance = _get_instance_from_profile(profile_name, scoped_config, missing_ok=True)
-        if not instance:
-            continue
-        if instance.start_url in instances and instance.region != instances[instance.start_url].region:
-            regions = f"{instance.region}, {instances[instance.start_url].region}"
-            LOGGER.warning(f"Region mismatch in config for {instance.start_url}: {regions}")
-        else:
-            instances[instance.start_url] = instance
-
-    return sorted(instances.values(), key=lambda i: i.start_url)
-
-def _validate_instance(instance: SSOInstance, source, start_url, start_url_source, region, region_source):
-    if start_url and instance.start_url != start_url:
-        message = f"start URL {instance.start_url} does not match {start_url} from {start_url_source}"
-        LOGGER.warn(message)
-    if region and instance.region != region:
-        message = f"region {instance.region} does not match {region} from {region_source}"
-        LOGGER.warn(message)
-
-def _find_instance_from_profile(
-        profile_name=None,
-        profile_source=None,
-        start_url=None,
-        start_url_source=None,
-        region=None,
-        region_source=None):
-    try:
-        session = botocore.session.Session(profile=profile_name)
-        instance = _get_instance_from_profile(profile_name, session.get_scoped_config())
-    except ProfileNotFound:
-        return None
-    if not instance:
-        return None
-    _validate_instance(instance, profile_source, start_url, start_url_source, region, region_source)
-    return instance
-
-def _get_specifier(
-        start_url=None,
-        start_url_source=None,
-        region=None,
-        region_source=None,
-        start_url_vars=None,
-        region_vars=None):
-
-    if start_url is None and region is None:
-        if start_url_vars:
-            start_url, start_url_source = _get(start_url_vars)
-        if region_vars:
-            region, region_source = _get(region_vars)
-
-    if start_url is None and region is None:
-        start_url, start_url_source = _get(START_URL_VARS)
-        region, region_source = _get(REGION_VARS)
-
-    return SSOInstance(start_url, region, start_url_source, region_source)
-
-def _specifier_matches(specifier, instance):
-    if specifier.start_url:
-        if specifier.start_url.startswith("http"):
-            if not specifier.start_url == instance.start_url:
-                return False, "does not match literal start URL"
-        elif not re.search(specifier.start_url, instance.start_url):
-            return False, "does not match regex start URL"
-        if specifier.region and specifier.region != instance.region:
-            LOGGER.warn(
-                f"Instance {instance.start_url} " +
-                f"from {instance.start_url_source} " +
-                f"has region {instance.region} " +
-                f"which does not match {specifier.region} " +
-                f"from {specifier.region_source}"
-            )
-
-    if specifier.region and specifier.region != instance.region:
-        return False, "does not match region"
-
-    if specifier.start_url:
-        if specifier.start_url.startswith("http"):
-            if specifier.region:
-                return True, "matches literal start URL and region"
-            else:
-                return True, "matches literal start URL and region"
-        elif specifier.region:
-            return True, "matches regex start URL and region"
-        else:
-            return True, "matches regex start URL"
-    else:
-        return True, "matches region"
-
-
-def find_all_instances(
-        start_url_vars=None,
-        region_vars=None):
-    unique_instances = []
-    all_instances = []
-
-    specifier = _get_specifier(
-        start_url=None,
-        start_url_source=None,
-        region=None,
-        region_source=None,
-        start_url_vars=start_url_vars,
-        region_vars=region_vars,
-    )
-
-    if specifier:
-        LOGGER.debug(f"Found instance in env vars: {specifier.to_str(region=True)}")
-        unique_instances.append(specifier)
-        all_instances.append(specifier)
-
-    session = botocore.session.Session(session_vars={
-        'profile': (None, None, None, None),
-        'region': (None, None, None, None),
-    })
-    config_instances = _get_all_instances_from_config(session.full_config)
-
-    LOGGER.debug(f"Found instances in config: {SSOInstance.to_strs(config_instances, region=True)}")
-
-    filtered_config_instances = list(i for i in config_instances if i not in unique_instances)
-    unique_instances.extend(filtered_config_instances)
-
-    all_instances.extend(config_instances)
-
-    return unique_instances, all_instances
-
-def find_instances(
-        profile_name=None,
-        profile_source=None,
-        start_url=None,
-        start_url_source=None,
-        region=None,
-        region_source=None,
-        start_url_vars=None,
-        region_vars=None):
-    if profile_name:
-        LOGGER.debug(f"Finding instance from profile {profile_name}")
-        instance = _find_instance_from_profile(
-            profile_name=profile_name,
-            profile_source=profile_source,
-            start_url=start_url,
-            start_url_source=start_url_source,
-            region=region,
-            region_source=region_source
+    return Specifier(
+        value=value,
+        source=Source(
+            type="env var",
+            name=name
         )
-        if instance:
-            return [instance], None, [instance]
-        else:
-            LOGGER.debug("No instance found in profile")
-            return [], None, []
-
-    specifier = _get_specifier(
-        start_url=start_url,
-        start_url_source=start_url_source,
-        region=region,
-        region_source=region_source,
-        start_url_vars=start_url_vars,
-        region_vars=region_vars,
     )
 
-    if specifier:
-        parts = [
-            f"Using Identity Center instance specifier"
-        ]
-        if specifier.start_url:
-            parts.extend([
-                f"{specifier.start_url}",
-                f"from {specifier.start_url_source}"
-            ])
-        if specifier.region:
-            if specifier.start_url:
-                parts.append("with")
-            parts.extend([
-                "region",
-                f"{specifier.region}",
-                f"from {specifier.region_source}"
-            ])
-        LOGGER.info(" ".join(parts))
-    else:
-        LOGGER.debug("No Identity Center instance specifier found")
+@dataclass(frozen=True)
+class FindAllSessionsResult:
+    unique_sessions: dict[str, Session]
+    all_sessions: list[Session]
+    malformed_session_errors: list[Session]
 
-    if specifier.start_url and specifier.region and specifier.start_url.startswith("http"):
-        LOGGER.debug("Specifier has literal start URL and region, not searching for instances")
-        return [specifier], specifier, [specifier]
+    def filter(self, specifier: Specifier) -> dict[str, Session]:
+        result = {}
+        for session in self.unique_sessions.values():
+            if specifier.matches(session):
+                result[session.session_name] = session
+        return result
 
-    session = botocore.session.Session(session_vars={
-        'profile': (None, None, None, None),
-        'region': (None, None, None, None),
-    })
-    all_instances = _get_all_instances_from_config(session.full_config)
+def find_all_sessions(botocore_session_full_config=None) -> FindAllSessionsResult:
+    if botocore_session_full_config is None:
+        botocore_session = botocore.session.Session(session_vars={
+            "profile": (None, None, None, None),
+            "region": (None, None, None, None),
+        })
+        botocore_session_full_config = botocore_session.full_config
+    
+    unique_sessions = {}
+    all_sessions = []
+    malformed_session_errors = []
 
-    LOGGER.debug(f"Found instances: {SSOInstance.to_strs(all_instances, region=True)}")
-
-    if not specifier:
-        LOGGER.debug("No specifier, returning all instances")
-        return all_instances, specifier, all_instances
-
-    instances = []
-    for instance in all_instances:
-        match, reason = _specifier_matches(specifier, instance)
-        if match:
-            LOGGER.debug(f"Instance {instance} {reason}")
-            instances.append(instance)
+    def _add(s: Union[Exception, Session]):
+        if s is None:
+            return
+        if isinstance(s, Exception):
+            malformed_session_errors.append(s)
         else:
-            LOGGER.debug(f"Instance {instance} {reason}")
+            if s.session_name not in unique_sessions:
+                unique_sessions[s.session_name] = s
+            all_sessions.append(s)
 
-    LOGGER.debug(f"Matching instances: {SSOInstance.to_strs(instances)}")
+    try:
+        specifier = get_specifier()
+        if specifier:
+            _add(specifier.session)
+    except InlineSessionError as e:
+        _add(e)
 
-    return instances, specifier, all_instances
+    for profile_name in botocore_session_full_config.get("profiles", {}).keys():
+        try:
+            session = get_session_from_config_profile(
+                profile_name=profile_name,
+                botocore_session_full_config=botocore_session_full_config
+            )
+            _add(session)
+        except NotAnSSOProfileError:
+            pass
+        except ConfigProfileError as e:
+            malformed_session_errors.append(e)
+    
+    for session_name in botocore_session_full_config.get("sso_sessions", {}).keys():
+        try:
+            session = get_session_from_config_session(
+                session_name=session_name,
+                botocore_session_full_config=botocore_session_full_config
+            )
+            _add(session)
+        except ConfigSessionError as e:
+            _add(e)
+    
+    return FindAllSessionsResult(
+        unique_sessions=unique_sessions,
+        all_sessions=all_sessions,
+        malformed_session_errors=malformed_session_errors
+    )
+
+def find_sessions(specifier: Specifier) -> dict[str, Session]:
+    sessions = find_all_sessions()
+    return sessions.filter(specifier)
+
+class SessionRetrievalError(Exception):
+    pass
+
+class ConfigProfileError(SessionRetrievalError):
+    pass
+
+class NotAnSSOProfileError(SessionRetrievalError):
+    pass
+
+def get_session_from_config_profile(
+        profile_name: str,
+        source: Source=None,
+        botocore_session_full_config=None) -> Session:
+    if botocore_session_full_config is None:
+        botocore_session = botocore.session.Session(session_vars={
+            "profile": (None, None, None, None),
+            "region": (None, None, None, None),
+        })
+        botocore_session_full_config = botocore_session.full_config
+    
+    if profile_name not in botocore_session_full_config.get("profiles", {}):
+        raise ConfigProfileError(f"Did not find config profile {profile_name}")
+
+    profile_config = botocore_session_full_config.get("profiles", {})[profile_name]
+    
+    if "sso_session" in profile_config:
+        session_name = profile_config["sso_session"]
+        LOGGER.debug(f"Config profile {profile_name} uses config session {session_name}")
+        new_source = Source(
+            type="config profile",
+            name=profile_name,
+            parent=source
+        )
+        try:
+            session = get_session_from_config_session(
+                session_name=session_name,
+                source=new_source,
+                botocore_session_full_config=botocore_session_full_config
+            )
+        except ConfigSessionError as e:
+            raise ConfigProfileError(f"Config profile {profile_name} uses an invalid config session: {str(e)}")
+        LOGGER.debug(f"Config profile {profile_name} has session {session}")
+        return session
+
+    start_url = profile_config.get("sso_start_url")
+    region = profile_config.get("sso_region")
+
+    if not start_url and not region:
+        raise NotAnSSOProfileError(f"Config profile {profile_name} is not an SSO profile")
+
+    if not start_url:
+        raise ConfigProfileError(f"Config profile {profile_name} is missing fields: sso_start_url")
+    
+    if not region:
+        raise ConfigProfileError(f"Config profile {profile_name} is missing fields: sso_region")
+
+    session = Session(
+        session_name=start_url,
+        source=Source(
+            type="config profile",
+            name=profile_name,
+            parent=source
+        ),
+        start_url=start_url,
+        region=region
+    )
+    LOGGER.debug(f"Config profile {profile_name} has inline session {session}")
+    return session
+
+class ConfigSessionError(SessionRetrievalError):
+    pass
+
+def get_session_from_config_session(
+        session_name: str,
+        source: Source=None,
+        botocore_session_full_config: dict=None) -> Session:
+    if botocore_session_full_config is None:
+        botocore_session = botocore.session.Session(session_vars={
+            "profile": (None, None, None, None),
+            "region": (None, None, None, None),
+        })
+        botocore_session_full_config = botocore_session.full_config
+    
+    if session_name not in botocore_session_full_config.get("sso_sessions", {}):
+        raise ConfigSessionError(f"Did not find config session {session_name}")
+
+    session_config = botocore_session_full_config.get("sso_sessions", {})[session_name]
+
+    start_url = session_config.get("sso_start_url")
+    region = session_config.get("sso_region")
+    
+    missing = []
+    if not start_url:
+        missing.append("sso_start_url")
+    if not region:
+        missing.append("sso_region")
+
+    if missing:
+        raise ConfigSessionError(f"Config session {session_name} is missing fields: {' '.join(missing)}")
+    
+    registration_scopes = None
+    if "sso_registration_scopes" in session_config:
+        raw_registration_scopes = session_config["sso_registration_scopes"]
+        try:
+            registration_scopes = parse_sso_registration_scopes(raw_registration_scopes)
+        except Exception as e:
+            raise (f"Config session {session_name} has malformed registration scopes {raw_registration_scopes}")
+    
+    session = Session(
+        session_name=session_name,
+        source=Source(
+            type="config session",
+            name=session_name,
+            parent=source
+        ),
+        start_url=start_url,
+        region=region,
+        registration_scopes=registration_scopes
+    )
+    LOGGER.debug(f"Config session {session_name} has session {session}")
+    return session

--- a/lib/aws_sso_lib/vendored_botocore/utils.py
+++ b/lib/aws_sso_lib/vendored_botocore/utils.py
@@ -12,7 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-# this is the new content of botocore.utils in the v2 branch
+# partial content of botocore.utils in the v2 branch of awscli
 
 import time
 import datetime
@@ -51,6 +51,17 @@ from botocore.utils import (
 
 from .exceptions import PendingAuthorizationExpiredError
 
+def _serialize_datetimes(obj, iso=False):
+    if isinstance(obj, datetime.datetime):
+        if iso:
+            return obj.isoformat()
+        return obj.strftime('%Y-%m-%dT%H:%M:%S%Z')
+    if isinstance(obj, (list, tuple)):
+        return list(_serialize_datetimes(v, iso=iso) for v in obj)
+    if isinstance(obj, dict):
+        return {key: _serialize_datetimes(value, iso=iso) for key, value in obj.items()}
+    return obj
+
 class SSOTokenFetcher(object):
     # The device flow RFC defines the slow down delay to be an additional
     # 5 seconds:
@@ -63,9 +74,14 @@ class SSOTokenFetcher(object):
     _GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
 
     def __init__(
-            self, sso_region, client_creator, cache=None,
-            on_pending_authorization=None, time_fetcher=None,
-            sleep=None, expiry_window=None,
+            self,
+            sso_region,
+            client_creator,
+            cache=None,
+            on_pending_authorization=None,
+            time_fetcher=None,
+            sleep=None,
+            expiry_window=None,
     ):
         self._sso_region = sso_region
         self._client_creator = client_creator
@@ -116,35 +132,66 @@ class SSOTokenFetcher(object):
         )
         return self._client_creator('sso-oidc', config=config)
 
-    def _register_client(self):
+    def _register_client(self, session_name, scopes):
         timestamp = self._time_fetcher()
-        response = self._client.register_client(
-            # NOTE: As far as I know client name will never be returned to the
-            # user. For now we'll just use botocore-client with the timestamp.
-            clientName='botocore-client-%s' % int(datetime2timestamp(timestamp)),
-            clientType=self._CLIENT_REGISTRATION_TYPE,
-        )
+        if session_name is None:
+            # Use a timestamp for the session name for legacy configuration
+            session_name = f"anonymous-{int(datetime2timestamp(timestamp))}"
+        register_kwargs = {
+            'clientName': f'aws-sso-util-{session_name}',
+            'clientType': self._CLIENT_REGISTRATION_TYPE,
+        }
+        if scopes:
+            register_kwargs['scopes'] = scopes
+        response = self._client.register_client(**register_kwargs)
         expires_at = response['clientSecretExpiresAt']
         expires_at = datetime.datetime.fromtimestamp(expires_at, tzutc())
         registration = {
             'clientId': response['clientId'],
             'clientSecret': response['clientSecret'],
             'expiresAt': expires_at,
-            'receivedAt': timestamp,
+            'receivedAt': timestamp.strftime('%Y-%m-%dT%H:%M:%S%Z'),
         }
+        if scopes:
+            registration['scopes'] = scopes
+        registration = _serialize_datetimes(registration)
         return registration
 
-    def _registration(self):
-        # Registration with the OIDC endpoint is regional, is good for roughly
-        # 90 days, and can be shared. This is currently scoped to individual
-        # tools and as such each tool has their own cached client id.
-        cache_key = 'botocore-client-id-%s' % self._sso_region
-        if cache_key in self._cache:
+    def _registration_cache_key(self, start_url, session_name, scopes):
+        # Registration is unique based on the following properties to ensure
+        # modifications to the registration do not affect the permissions of
+        # tokens derived for other start URLs.
+        args = {
+            'tool': 'botocore',
+            'startUrl': start_url,
+            'region': self._sso_region,
+            'scopes': scopes,
+            'session_name': session_name,
+        }
+        cache_args = json.dumps(args, sort_keys=True).encode('utf-8')
+        return hashlib.sha1(cache_args).hexdigest()
+
+    def _registration(
+        self,
+        start_url,
+        session_name,
+        scopes,
+        force_refresh=False,
+    ):
+        cache_key = self._registration_cache_key(
+            start_url,
+            session_name,
+            scopes,
+        )
+        if not force_refresh and cache_key in self._cache:
             registration = self._cache[cache_key]
             if not self._is_expired(registration):
                 return registration
 
-        registration = self._register_client()
+        registration = self._register_client(
+            session_name,
+            scopes,
+        )
         self._cache[cache_key] = registration
         return registration
 
@@ -170,9 +217,25 @@ class SSOTokenFetcher(object):
             authorization['interval'] = response['interval']
         return authorization
 
-    def _poll_for_token(self, start_url):
-        registration = self._registration()
+    def _poll_for_token(self, start_url, session_name, registration_scopes):
+        registration = self._registration(
+            start_url,
+            session_name,
+            registration_scopes,
+        )
         authorization = self._authorize_client(start_url, registration)
+
+        interval = authorization.get('interval', self._DEFAULT_INTERVAL)
+
+        # In some circumstances the client may be pre-authorized to generate a
+        # token and it's not necessary to display the authorization message. We
+        # do a single create token attempt before displaying the message and
+        # falling back to the polling loop.
+        interval, token = self._create_token_attempt(
+            start_url, registration, authorization, interval
+        )
+        if token is not None:
+            return token
 
         if self._on_pending_authorization:
             # This callback can display the user code / verification URI
@@ -180,67 +243,105 @@ class SSOTokenFetcher(object):
             # back could even be used to auto open a browser.
             self._on_pending_authorization(**authorization)
 
-        interval = authorization.get('interval', self._DEFAULT_INTERVAL)
         # NOTE: This loop currently relies on the service to either return
         # a valid token or a ExpiredTokenException to break the loop. If this
         # proves to be problematic it may be worth adding an additional
         # mechanism to control timing this loop out.
         while True:
-            try:
-                response = self._client.create_token(
-                    grantType=self._GRANT_TYPE,
-                    clientId=registration['clientId'],
-                    clientSecret=registration['clientSecret'],
-                    deviceCode=authorization['deviceCode'],
-                )
-                expires_in = datetime.timedelta(seconds=response['expiresIn'])
-                timestamp = self._time_fetcher()
-                token = {
-                    'startUrl': start_url,
-                    'region': self._sso_region,
-                    'accessToken': response['accessToken'],
-                    'expiresAt': timestamp + expires_in,
-                    'receivedAt': timestamp,
-                }
+            interval, token = self._create_token_attempt(
+                start_url, registration, authorization, interval
+            )
+            if token is not None:
                 return token
-            except self._client.exceptions.SlowDownException:
-                interval += self._SLOW_DOWN_DELAY
-            except self._client.exceptions.AuthorizationPendingException:
-                pass
-            except self._client.exceptions.ExpiredTokenException:
-                raise PendingAuthorizationExpiredError()
             self._sleep(interval)
 
-    def _cache_key(self, start_url):
-        return hashlib.sha1(start_url.encode('utf-8')).hexdigest()
+    def _create_token_attempt(
+        self, start_url, registration, authorization, interval,
+    ):
+        try:
+            response = self._client.create_token(
+                grantType=self._GRANT_TYPE,
+                clientId=registration['clientId'],
+                clientSecret=registration['clientSecret'],
+                deviceCode=authorization['deviceCode'],
+            )
+            expires_in = datetime.timedelta(seconds=response['expiresIn'])
+            timestamp = self._time_fetcher()
+            token = {
+                'startUrl': start_url,
+                'region': self._sso_region,
+                'accessToken': response['accessToken'],
+                'expiresAt': timestamp + expires_in,
+                'receivedAt': timestamp,
+                # Cache the registration alongside the token
+                'clientId': registration['clientId'],
+                'clientSecret': registration['clientSecret'],
+                'registrationExpiresAt': registration['expiresAt'],
+            }
+            if 'refreshToken' in response:
+                token['refreshToken'] = response['refreshToken']
+            token = _serialize_datetimes(token)
+            return interval, token
+        except self._client.exceptions.SlowDownException:
+            interval += self._SLOW_DOWN_DELAY
+        except self._client.exceptions.AuthorizationPendingException:
+            pass
+        except self._client.exceptions.ExpiredTokenException:
+            raise PendingAuthorizationExpiredError()
+        return interval, None
 
-    def _token(self, start_url, force_refresh):
-        cache_key = self._cache_key(start_url)
+    def _token_cache_key(self, start_url, session_name):
+        input_str = start_url
+        if session_name is not None:
+            input_str = session_name
+        return hashlib.sha1(input_str.encode('utf-8')).hexdigest()
+
+    def _token(
+        self,
+        start_url,
+        force_refresh,
+        registration_scopes,
+        session_name,
+    ):
+        cache_key = self._token_cache_key(start_url, session_name)
         # Only obey the token cache if we are not forcing a refresh.
         if not force_refresh and cache_key in self._cache:
             token = self._cache[cache_key]
+            # TODO: Should probably try to refresh token here
             if not self._is_expired(token):
                 return token
 
-        token = self._poll_for_token(start_url)
+        token = self._poll_for_token(
+            start_url,
+            session_name,
+            registration_scopes,
+        )
         self._cache[cache_key] = token
         return token
 
-    def fetch_token(self, start_url, force_refresh=False):
-        return self._token(start_url, force_refresh)
+    def fetch_token(
+        self,
+        start_url,
+        force_refresh=False,
+        registration_scopes=None,
+        session_name=None,
+    ):
+        return self._token(
+            start_url,
+            force_refresh,
+            registration_scopes,
+            session_name,
+        )
 
-    def get_token_from_cache(self, start_url):
-        cache_key = self._cache_key(start_url)
+    def get_token_from_cache(self, start_url, session_name=None):
+        cache_key = self._token_cache_key(start_url, session_name)
         if cache_key in self._cache:
             token = self._cache[cache_key]
             return token
         return None
 
-    def is_token_expired(self, token):
-        return self._is_expired(token)
-
-    def pop_token_from_cache(self, start_url):
-        cache_key = self._cache_key(start_url)
+    def pop_token_from_cache(self, start_url, session_name=None):
+        cache_key = self._cache_key(start_url, session_name)
         # Only obey the token cache if we are not forcing a refresh.
         if cache_key in self._cache:
             token = self._cache[cache_key]
@@ -251,3 +352,6 @@ class SSOTokenFetcher(object):
             return token
         else:
             return None
+    
+    def is_token_expired(self, token):
+        return self._is_expired(token)


### PR DESCRIPTION
Updates the BrowserHandler "DEFAULT_BROWSER_MESSAGE" and "DEFAULT_NO_BROWSER_MESSAGE" text 
to print an alternate URL that includes the autofilled authorization code.
Message format conforms to syntax of the sso/utils.py in aws-cli. 
Cleaned up for single commit.
Tested successfully locally.