### PR TITLE
Release CLI v4.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## `aws-sso-util`
 
+### CLI v4.32
+* Update to PyYAML 6.0.1 for Cython issue ([#104](https://github.com/benkehoe/aws-sso-util/issues/104) (see https://github.com/yaml/pyyaml/issues/601)).
+* Update login text to match AWS CLI, provide inputs for custom login text to use `verificationUriComplete` ([#92](https://github.com/benkehoe/aws-sso-util/issues/)).
+* Error handling for missing expiration in cached token.
+
 ### CLI v4.31
 * CloudFormation functionality now excludes suspended accounts from OU traversal ([#80](https://github.com/benkehoe/aws-sso-util/issues/80) via [#81](https://github.com/benkehoe/aws-sso-util/pull/81)).
 * Upgrade to `click` 8 ([#85](https://github.com/benkehoe/aws-sso-util/issues/85)).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 * [Imran](https://github.com/fai555)
 * [O'Shaughnessy Evans](https://github.com/oshaughnessy)
 * [Anthony Engelstad](https://github.com/anton0)
+* [Shaun Dewberry](https://github.com/shaundewberry)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -29,7 +29,7 @@ jsonschema = "^3.2.0"
 aws-error-utils = "^2.4"
 python-dateutil = "^2.8.1"
 aws-sso-lib = "^1.13.0"
-# aws-sso-lib = { path = "../lib" }
+# aws-sso-lib = { path = "../lib", develop = true }
 requests = "^2.26.0"
 
 [tool.poetry.dev-dependencies]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-sso-util"
-version = "4.31.0" # change in aws_sso_util/__init__.py too
+version = "4.32.0" # change in aws_sso_util/__init__.py too
 description = "Utilities to make AWS SSO easier"
 authors = ["Ben Kehoe <ben@kehoe.io>"]
 license = "Apache-2.0"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -24,7 +24,7 @@ python = "^3.7"
 # botocore = {git = "https://github.com/boto/botocore.git", rev = "v2"}
 click = ">=8.0.0, < 9.0.0"
 boto3 = ">=1.24.60, <2.0.0"
-pyyaml = "^5.3.1"
+pyyaml = ">=6.0.1, <7.0.0"
 jsonschema = "^3.2.0"
 aws-error-utils = "^2.4"
 python-dateutil = "^2.8.1"

--- a/cli/src/aws_sso_util/__init__.py
+++ b/cli/src/aws_sso_util/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '4.31.0' # change in pyproject.toml too
+__version__ = '4.32.0' # change in pyproject.toml too

--- a/cli/src/aws_sso_util/check.py
+++ b/cli/src/aws_sso_util/check.py
@@ -238,7 +238,7 @@ def check(
             token = login(instance.start_url, instance.region, force_refresh=True)
         except Exception as e:
             LOGGER.debug(traceback.format_exc())
-            LOGGER.error(f"Exception during login: {e}")
+            LOGGER.error(f"Exception during login: {e.__class__.__name__} {e}")
             sys.exit(201)
     else:
         try:
@@ -254,6 +254,9 @@ def check(
                     + f"Log in with `aws-sso-util login {instance.start_url} {instance.region}` or use the --force-refresh option."
                 )
                 LOGGER.error(message)
+                sys.exit(201)
+            elif 'expiresAt' not in token:
+                LOGGER.error("The token is missing the 'expiresAt' key, which should always be present.")
                 sys.exit(201)
             elif token_fetcher.is_token_expired(token):
                 message = (
@@ -281,7 +284,7 @@ def check(
                 LOGGER.error(f"The Identity Center cache file ({msg}) may have the wrong permissions{coda}")
                 sys.exit(201)
 
-            LOGGER.error(f"Exception in loading token: {e}")
+            LOGGER.error(f"Exception in loading token: {e.__class__.__name__} {e}")
             os_error = extract_error(e, OSError)
             if os_error and os_error.filename:
                 LOGGER.error(f"The Identity Center cache file is located at {os_error.filename}")
@@ -310,7 +313,7 @@ def check(
                 err_msg = err_msg.replace("\n", " ")
             LOGGER.error(err_msg)
         except Exception as e:
-            LOGGER.error(f"Exception using token: {e}")
+            LOGGER.error(f"Exception using token: {e.__class__.__name__} {e}")
         return
     elif not account:
         accounts = {}

--- a/lib/README.md
+++ b/lib/README.md
@@ -51,7 +51,7 @@ If the user is logged in and `force_refresh` is `False`, no action is taken.
 
 Normally, it will attempt to automatically open the user's browser to log in, as well as printing the URL and code to stderr as a fallback. However, if `disable_browser` is `True`, or if `disable_browser` is `None` (the default) and the environment variable `AWS_SSO_DISABLE_BROWSER` is set to `1` or `true`, only the message with the URL and code will be printed.
 
-A custom message can be printed by setting `message` to a template string using `{url}` and `{code}` as placeholders.
+A custom message can be printed by setting `message` to a template string using any or all of `{url}`, `{code}`, and `{urlWithCode}` as placeholders.
 The message can be suppressed by setting `message` to `False`.
 
 To fully control the communication with the user, use the `user_auth_handler` parameter.

--- a/lib/aws_sso_lib/browser.py
+++ b/lib/aws_sso_lib/browser.py
@@ -29,6 +29,10 @@ authorize this request, open the following URL:
 Then enter the code:
 
 {code}
+
+Alternatively, you may visit the following URL which will autofill the code upon loading:
+
+{urlWithCode}
 """)
 
 DEFAULT_NO_BROWSER_MESSAGE = textwrap.dedent("""\
@@ -40,6 +44,10 @@ Open the following URL in a browser:
 Then enter the code:
 
 {code}
+
+Alternatively, you may visit the following URL which will autofill the code upon loading:
+
+{urlWithCode}
 """)
 
 class OpenBrowserHandler(object):
@@ -71,7 +79,9 @@ class OpenBrowserHandler(object):
                 url=verificationUri,
                 code=userCode,
                 verificationUri=verificationUri,
-                userCode=userCode
+                userCode=userCode,
+                urlWithCode=verificationUriComplete,
+                verificationUriComplete=verificationUriComplete
             )
 
             print(message, file=self._outfile)

--- a/lib/aws_sso_lib/vendored_botocore/utils.py
+++ b/lib/aws_sso_lib/vendored_botocore/utils.py
@@ -51,6 +51,8 @@ from botocore.utils import (
 
 from .exceptions import PendingAuthorizationExpiredError
 
+logger = logging.getLogger(__name__)
+
 class SSOTokenFetcher(object):
     # The device flow RFC defines the slow down delay to be an additional
     # 5 seconds:
@@ -96,6 +98,9 @@ class SSOTokenFetcher(object):
         return dateutil.parser.parse(value)
 
     def _is_expired(self, response):
+        if 'expiresAt' not in response:
+            logger.debug("expiresAt missing from token cache entry, treating as expired")
+            return True
         end_time = self._parse_if_needed(response['expiresAt'])
         seconds = total_seconds(end_time - self._time_fetcher())
         if callable(self._expiry_window):


### PR DESCRIPTION
### CLI v4.32
* Update to PyYAML 6.0.1 for Cython issue (see https://github.com/yaml/pyyaml/issues/601) ([#104](https://github.com/benkehoe/aws-sso-util/issues/104)).
* Update login text to match AWS CLI, provide inputs for custom login text to use `verificationUriComplete` ([#92](https://github.com/benkehoe/aws-sso-util/issues/)).
* Error handling for missing expiration in cached token.
