### PR TITLE
Docs: specify needed SAM capabilities in macro install instructions

### DIFF
--- a/docs/cloudformation.md
+++ b/docs/cloudformation.md
@@ -52,7 +52,7 @@ This should be able to be a [SAR app](https://aws.amazon.com/serverless/serverle
 git clone https://github.com/benkehoe/aws-sso-util
 cd aws-sso-util/macro
 sam build --use-container
-sam deploy --guided
+sam deploy --capabilities "CAPABILITY_IAM,CAPABILITY_NAMED_IAM" --guided
 ```
 
 The macro template has the following parameters (note that for the values that can be set in the `Metadata` section of the template, as noted below, the template values take precedence for that template's generation):


### PR DESCRIPTION
These avoids a first failed deployment with the annoying error:

> Error: Failed to create changeset for the stack: aws-sso-util-cf-macro, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Requires capabilities : [CAPABILITY_NAMED_IAM]