### PR TITLE
Update AWS SSO configuration handling (reading)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@
 * [O'Shaughnessy Evans](https://github.com/oshaughnessy)
 * [Anthony Engelstad](https://github.com/anton0)
 * [Shaun Dewberry](https://github.com/shaundewberry)
+* [ikeyan](https://github.com/ikeyan)

--- a/cli/src/aws_sso_util/cfn.py
+++ b/cli/src/aws_sso_util/cfn.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import argparse
 from collections import namedtuple, OrderedDict
 from pathlib import Path
 import logging

--- a/cli/src/aws_sso_util/configure_profile.py
+++ b/cli/src/aws_sso_util/configure_profile.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import os
 import subprocess
 import sys

--- a/cli/src/aws_sso_util/deploy_macro.py
+++ b/cli/src/aws_sso_util/deploy_macro.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import argparse
 import subprocess
 import tempfile
 import sys

--- a/cli/src/aws_sso_util/lookup.py
+++ b/cli/src/aws_sso_util/lookup.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import argparse
 import sys
 import os
 from collections import namedtuple

--- a/cli/src/aws_sso_util/populate_profiles.py
+++ b/cli/src/aws_sso_util/populate_profiles.py
@@ -13,7 +13,6 @@
 
 import sys
 import os
-import argparse
 import logging
 import json
 import subprocess


### PR DESCRIPTION
Support `sso_session` attributes and `[sso-session]` sections when reading from config in `check` and `credential-process` commands
https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-token.html

This PR does not update how `configure profile` and `configure populate`  update the config.



